### PR TITLE
feat: Add RegisterControllerTest for API v2 oc: 4404

### DIFF
--- a/tests/Feature/V2/RegisterControllerTest.php
+++ b/tests/Feature/V2/RegisterControllerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\V2;
+
+use App\Models\Company;
+use App\Models\User;
+use App\Models\UserType;
+use App\Models\Zone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testRegisterNameFieldRequired()
+    {
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmapp'
+        ]);
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString('The name field is required', $content['message']);
+    }
+
+    public function testRegisterAppCompanyIdFieldRequired()
+    {
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmapp',
+            'name' => 'myName'
+        ]);
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString('The app company id field is required', $content['message']);
+    }
+
+    public function testRegisterPasswordMustBeAtLeast8()
+    {
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmapp',
+            'name' => 'myName',
+            'app_company_id' => 10
+
+        ]);
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString('The password must be at least 8 characters', $content['message']);
+    }
+
+    public function testRegisterPasswordConfirmationDoesNotMatchNoField()
+    {
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmappwebmapp',
+            'password_confirmation' => 'ppambewppambew',
+            'name' => 'myName',
+            'app_company_id' => 10
+        ]);
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString('The password confirmation does not match', $content['message']);
+    }
+
+    public function testRegisterDuplicateEmail()
+    {
+        $existingUser = User::factory()->create(['email' => 'team@webmapp.it']);
+
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmappwebmapp',
+            'password_confirmation' => 'webmappwebmapp',
+            'name' => 'myName',
+            'app_company_id' => 10
+        ]);
+
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString('The email has already been taken', $content['message']);
+    }
+
+    public function testRegisterSuccess()
+    {
+        $z = Zone::factory()->create();
+        $u = UserType::factory()->create();
+        $c = Company::factory()->create();
+
+        $response = $this->post('/api/v2/register', [
+            'email' => 'team@webmapp.it',
+            'password' => 'webmappwebmapp',
+            'password_confirmation' => 'webmappwebmapp',
+            'name' => 'myName',
+            'form_data' => ['phone_number' => '3333333333', 'fiscal_code' => 'PPPPPP1P11P111P'],
+            'app_company_id' => $c->id,
+            'zone_id' => $z->id,
+            'user_type_id' => $u->id,
+            'location' => [10, 45],
+            'address' => 'via da qua',
+        ]);
+        $this->assertSame(200, $response->status());
+        $content = json_decode($response->content());
+        $this->assertSame(true, $content->success);
+        $this->assertNotEmpty($content->data);
+    }
+}

--- a/tests/Feature/V2/RegisterControllerTest.php
+++ b/tests/Feature/V2/RegisterControllerTest.php
@@ -6,12 +6,20 @@ use App\Models\Company;
 use App\Models\User;
 use App\Models\UserType;
 use App\Models\Zone;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class RegisterControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
+
+    private function assertErrorResponse($response, $expectedMessage)
+    {
+        $this->assertSame(400, $response->status());
+        $content = json_decode($response->content(), true);
+        $this->assertFalse($content['success']);
+        $this->assertStringContainsString($expectedMessage, $content['message']);
+    }
 
     public function testRegisterNameFieldRequired()
     {
@@ -19,10 +27,7 @@ class RegisterControllerTest extends TestCase
             'email' => 'team@webmapp.it',
             'password' => 'webmapp'
         ]);
-        $this->assertSame(400, $response->status());
-        $content = json_decode($response->content(), true);
-        $this->assertFalse($content['success']);
-        $this->assertStringContainsString('The name field is required', $content['message']);
+        $this->assertErrorResponse($response, 'The name field is required');
     }
 
     public function testRegisterAppCompanyIdFieldRequired()
@@ -32,10 +37,7 @@ class RegisterControllerTest extends TestCase
             'password' => 'webmapp',
             'name' => 'myName'
         ]);
-        $this->assertSame(400, $response->status());
-        $content = json_decode($response->content(), true);
-        $this->assertFalse($content['success']);
-        $this->assertStringContainsString('The app company id field is required', $content['message']);
+        $this->assertErrorResponse($response, 'The app company id field is required');
     }
 
     public function testRegisterPasswordMustBeAtLeast8()
@@ -45,12 +47,8 @@ class RegisterControllerTest extends TestCase
             'password' => 'webmapp',
             'name' => 'myName',
             'app_company_id' => 10
-
         ]);
-        $this->assertSame(400, $response->status());
-        $content = json_decode($response->content(), true);
-        $this->assertFalse($content['success']);
-        $this->assertStringContainsString('The password must be at least 8 characters', $content['message']);
+        $this->assertErrorResponse($response, 'The password must be at least 8 characters');
     }
 
     public function testRegisterPasswordConfirmationDoesNotMatchNoField()
@@ -62,10 +60,7 @@ class RegisterControllerTest extends TestCase
             'name' => 'myName',
             'app_company_id' => 10
         ]);
-        $this->assertSame(400, $response->status());
-        $content = json_decode($response->content(), true);
-        $this->assertFalse($content['success']);
-        $this->assertStringContainsString('The password confirmation does not match', $content['message']);
+        $this->assertErrorResponse($response, 'The password confirmation does not match');
     }
 
     public function testRegisterDuplicateEmail()
@@ -80,10 +75,7 @@ class RegisterControllerTest extends TestCase
             'app_company_id' => 10
         ]);
 
-        $this->assertSame(400, $response->status());
-        $content = json_decode($response->content(), true);
-        $this->assertFalse($content['success']);
-        $this->assertStringContainsString('The email has already been taken', $content['message']);
+        $this->assertErrorResponse($response, 'The email has already been taken');
     }
 
     public function testRegisterSuccess()


### PR DESCRIPTION
This commit adds the RegisterControllerTest class to test the registration functionality of the API version 2. It includes tests for required fields, password length validation, password confirmation matching, duplicate email check, and successful registration.
