### PR TITLE
chore: Added a series of tests for Verification Controller oc:4478

### DIFF
--- a/app/Http/Controllers/VerificationController.php
+++ b/app/Http/Controllers/VerificationController.php
@@ -13,7 +13,11 @@ class VerificationController extends Controller
             return $this->sendError("Invalid/Expired url provided.");
         }
 
-        $user = User::findOrFail($user_id);
+        try {
+            $user = User::findOrFail($user_id);
+        } catch (\Exception $e) {
+            return $this->sendError("User not found.");
+        }
 
         if (!$user->hasVerifiedEmail()) {
             $user->markEmailAsVerified();
@@ -36,7 +40,11 @@ class VerificationController extends Controller
             return $this->sendError([], "you are not registered");
         }
         $userID = $userFromAuth->id;
-        $user = User::findOrFail($userID);
+        try {
+            $user = User::findOrFail($userID);
+        } catch (\Exception $e) {
+            return $this->sendError([], "User not found.");
+        }
 
         if ($user->hasVerifiedEmail()) {
             return $this->sendResponse([], "Email already verified.");

--- a/routes/api.php
+++ b/routes/api.php
@@ -186,5 +186,5 @@ Route::prefix('v2')->group(function () {
     Route::middleware('auth:sanctum')->post('/address/create', [AddressController::class, 'create']);
     Route::middleware('auth:sanctum')->get('/address/index', [AddressController::class, 'index']);
     Route::get('email/resend', [VerificationController::class, 'resend']);
-    Route::get('email/verify/{id}', [VerificationController::class, 'verify'])->middleware('signed');
+    Route::get('email/verify/{id}', [VerificationController::class, 'verify'])->middleware('signed')->name('verificationV2.verify');
 });

--- a/tests/Feature/V2/VerificationControllerTest.php
+++ b/tests/Feature/V2/VerificationControllerTest.php
@@ -1,0 +1,118 @@
+<?php
+namespace Tests\Feature\V2;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Carbon\Carbon;
+use App\Models\Company;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Auth\Notifications\VerifyEmail;
+class VerificationControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+    private $verifiedUser;
+    private $company;   
+    private $unverifiedUser;
+    const API_PREFIX = 'api/v2/';
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->company = Company::factory()->create();
+        $this->verifiedUser = User::factory()->create(['app_company_id' => $this->company->id, 'email' => 'test@test.com']);
+        $this->unverifiedUser = User::factory()->unverified()->create(['app_company_id' => $this->company->id, 'email' => 'test2@test.com']);
+    }
+
+    /** @test */
+    public function VerifyTestWithUserNotVerified()
+    {
+        $this->get($this->getSignatureForUser($this->unverifiedUser))
+            ->assertStatus(200)
+            ->assertViewIs('auth.verifyemail')
+            ->assertViewHas('already_validated', false);
+
+        $this->assertTrue($this->unverifiedUser->fresh()->hasVerifiedEmail());
+    }
+
+    /** @test */
+    public function VerifyTestWithUserAlreadyVerified()
+    {
+        $this->get($this->getSignatureForUser($this->verifiedUser))
+            ->assertStatus(200)
+            ->assertViewIs('auth.verifyemail')
+            ->assertViewHas('already_validated', true);
+    }
+
+    /** @test */
+    public function VerifyTestWithInvalidSignature()
+    {
+        $this->get($this->getSignatureForUser($this->unverifiedUser, false))
+            ->assertStatus(400)
+            ->assertJson(['message' => 'Invalid signature.']);
+    }
+
+    /** @test */
+    public function VerifyTestWithUserNotExisting()
+    {
+        $this->unverifiedUser->id = 0;
+        $this->get($this->getSignatureForUser($this->unverifiedUser))
+            ->assertStatus(400)
+            ->assertJson(['message' => 'User not found.']);
+    }
+
+
+    /** @test */
+
+    public function ResendTest()
+    {
+        Notification::fake();
+        Sanctum::actingAs($this->unverifiedUser);
+        $this->get(self::API_PREFIX . 'email/resend')
+            ->assertStatus(200)
+            ->assertJson(['message' => 'Email verification link sent on your email id']);
+
+        Notification::assertSentTo($this->unverifiedUser, VerifyEmail::class);
+    }
+
+    /** @test */
+    public function ResendTestWithUserAlreadyVerified()
+    {
+        Sanctum::actingAs($this->verifiedUser);
+        $this->get(self::API_PREFIX . 'email/resend')
+            ->assertStatus(200)
+            ->assertJson(['message' => 'Email already verified.']);
+    }
+
+    /** @test */
+    public function ResendTestWithUserNotRegistered()
+    {
+        $this->get(self::API_PREFIX . 'email/resend')
+            ->assertStatus(400)
+            ->assertJson(['data' => 'you are not registered']);
+    }
+
+    /** @test */
+    public function ResendTestWithNonExistantUserLoggedIn()
+    {
+        $this->unverifiedUser->id = 0;
+        Sanctum::actingAs($this->unverifiedUser);
+        $this->get(self::API_PREFIX . 'email/resend')
+            ->assertStatus(400)
+            ->assertJson(['data' => 'User not found.']);
+    }
+
+    private function getSignatureForUser($user, $valid = true)
+    {
+        $expirationTime = $valid ? 
+            Carbon::now()->addMinutes(10) : 
+            Carbon::now()->subMinutes(10);
+
+        return URL::temporarySignedRoute(
+            "verificationV2.verify",
+            $expirationTime,
+            ['id' => $user->id]
+        );
+    }
+
+}


### PR DESCRIPTION
In questo commit ho:
- Creato il test
- Aggiunto un try-catch attorno ad un metodo in grado di provocare eccezioni se fallisce
- Aggiunto un nome al metodo Signed specifico per l'API V2

Nota: L'uso di un controllo sulla correttezza del url all'interno del metodo "Verify" sembra essere irraggiungibile: Se l'url è invalido per qualsiasi motivo, un eccezione salta ancora prima di arrivare nella funzione.
Nota 2: Nonostante lo abbia incluso all'interno di un Try-catch, l'uso della funzione "findOrFail" per trovare l'user dato l'ID dell'user già autenticato sembra essere ridondante. 