### PR TITLE
feat(nova): 🌸 display styled zone labels in grid layout on index view OC:5940

### DIFF
--- a/app/Nova/PushNotification.php
+++ b/app/Nova/PushNotification.php
@@ -4,6 +4,7 @@ namespace App\Nova;
 
 use App\Models\Company;
 use Exception;
+use HTML5;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Date;
 use Laravel\Nova\Fields\DateTime;
@@ -81,34 +82,37 @@ class PushNotification extends Resource
                     ->pluck('label')
                     ->toArray();
 
-                return '<div style="
-                        font-weight: bold; 
-                        word-break: break-word; 
-                        white-space: normal;
-                        display: grid;
-                        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-                        overflow-y: auto;
-                        gap: 8px;
-                        grid-auto-flow: dense;
-                        ">'
+                return <<<HTML
+<div style="
+    font-weight: bold; 
+    word-break: break-word; 
+    white-space: normal;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    overflow-y: auto;
+    gap: 8px;
+    grid-auto-flow: dense;
+">
+HTML
                     . collect($zones)->map(function ($label) {
-                        return '<span style="
-                                background-color: #0EA5E9;
-                                color: #fff;
-                                font-weight: 600;
-                                font-size: 14px;
-                                padding: 4px 8px;
-                                border-radius: 5px;
-                                overflow: hidden;
-                                display: -webkit-box;
-                                -webkit-box-orient: vertical;
-                                -webkit-line-clamp: 1;
-                            "
-                            title="' . ($label) . '">'
-                            . e($label) .
-                            '</span>';
-                    })->implode('') .
-                    '</div>';
+                        $escaped = e($label);
+                        return <<<HTML
+<span style="
+    background-color: #0EA5E9;
+    color: #fff;
+    font-weight: 600;
+    font-size: 14px;
+    padding: 4px 8px;
+    border-radius: 5px;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+" title="{$label}">{$escaped}</span>
+HTML;
+                    })->implode('') . <<<HTML
+</div>
+HTML;
             })
                 ->onlyOnIndex()
                 ->asHtml(),

--- a/app/Nova/PushNotification.php
+++ b/app/Nova/PushNotification.php
@@ -45,7 +45,9 @@ class PushNotification extends Resource
      * @var array
      */
     public static $search = [
-        'id', 'title', 'message'
+        'id',
+        'title',
+        'message'
     ];
 
     /**
@@ -70,8 +72,47 @@ class PushNotification extends Resource
                     $user = Auth::user();
                     return $user->companyWhereAdmin->zones->whereIn('id', $value)->pluck('label')->toArray();
                 })
-                ->nullable(),
-            ];
+                ->nullable()
+                ->hideFromIndex(),
+            Text::make(__('Zone'), function () {
+                $user = Auth::user();
+                $zones = $user->companyWhereAdmin->zones
+                    ->whereIn('id', $this->zone_ids ?? [])
+                    ->pluck('label')
+                    ->toArray();
+
+                return '<div style="
+                        font-weight: bold; 
+                        word-break: break-word; 
+                        white-space: normal;
+                        display: grid;
+                        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+                        overflow-y: auto;
+                        gap: 8px;
+                        grid-auto-flow: dense;
+                        ">'
+                    . collect($zones)->map(function ($label) {
+                        return '<span style="
+                                background-color: #0EA5E9;
+                                color: #fff;
+                                font-weight: 600;
+                                font-size: 14px;
+                                padding: 4px 8px;
+                                border-radius: 5px;
+                                overflow: hidden;
+                                display: -webkit-box;
+                                -webkit-box-orient: vertical;
+                                -webkit-line-clamp: 1;
+                            "
+                            title="' . ($label) . '">'
+                            . e($label) .
+                            '</span>';
+                    })->implode('') .
+                    '</div>';
+            })
+                ->onlyOnIndex()
+                ->asHtml(),
+        ];
     }
     private function getZones($fields = ['label', 'id'])
     {


### PR DESCRIPTION
- Render the user's zones as styled tags within a responsive grid layout on the Nova index view.
- Applied custom HTML and inline CSS for improved readability, responsiveness, and aesthetics.
- Limited to visible zones where the user is an admin.