### PR TITLE
feat(PushNotification): ✨ display 'All zones' when applicable OC: 5968

### DIFF
--- a/app/Nova/PushNotification.php
+++ b/app/Nova/PushNotification.php
@@ -77,10 +77,14 @@ class PushNotification extends Resource
                 ->hideFromIndex(),
             Text::make(__('Zone'), function () {
                 $user = Auth::user();
+                $allZones = $user->companyWhereAdmin->zones;
                 $zones = $user->companyWhereAdmin->zones
                     ->whereIn('id', $this->zone_ids ?? [])
                     ->pluck('label')
                     ->toArray();
+                if (count($zones) === $allZones->count()) {
+                    return '<span style="font-weight: 600;">' . __('All zones') . '</span>';
+                }
 
                 return <<<HTML
 <div style="

--- a/lang/vendor/nova/en.json
+++ b/lang/vendor/nova/en.json
@@ -443,5 +443,6 @@
   "Light": "Light",
   "Dark": "Dark",
   "System": "System",
-  "There are no fields to display.": "There are no fields to display."
+  "There are no fields to display.": "There are no fields to display.",
+  "All zones": "All zones"
 }

--- a/lang/vendor/nova/it.json
+++ b/lang/vendor/nova/it.json
@@ -598,6 +598,6 @@
     "Don't mark as read": "Non segnare come letto",
     "Are you sure you want to mark this ticket as execute?": "Sei sicuro di voler segnare questo ticket come eseguito?",
     "Mark as execute": "Segna come eseguito",
-    "Don't mark as execute": "Non segnare come eseguito"
-
+    "Don't mark as execute": "Non segnare come eseguito",
+    "All zones": "Tutte le zone"
 }


### PR DESCRIPTION
- Added logic to check if the selected zones include all available zones for the user.
- Display 'All zones' with a bold style when all zones are selected.
- Updated English and Italian localization files to include the new "All zones" label.