### PR TITLE
fix(oc:8057): add --model PendingAttachment to model:prune scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,18 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fix scheduler model:prune PendingAttachment Nova/Trix | oc:8057 | `app/Console/Kernel.php` | Aggiunto `--model PendingAttachment` al prune notturno per eliminare file temporanei Trix accumulati |
 | Revisione test suite: db di test dedicato | oc:7991 | `tests/TestCase.php`, `phpunit.xml`, `app/Providers/RouteServiceProvider.php`, `.github/workflows/*.yml` | DB `pap_test` dedicato, guard anti-dev-db, throttle disabilitato in testing, CI su PostgreSQL 14+PostGIS |
 | Smistamento automatico segnalazioni Lunigiana | oc:7616 | `config/lunigiana.php`, `app/Models/Ticket.php`, `app/Http/Controllers/TicketController.php` | Duplica le email ticket verso urp@lunigianaambiente.it per le zone Lunigiana di ERSU |
 | Bug oc:7609 — bloccanti 3 e 4 backend | oc:8054 | `app/Http/Controllers/CalendarController.php`, `app/Http/Controllers/TicketController.php`, `app/Nova/Ticket.php`, `resources/views/emails/tickets/created.blade.php` | Validazione server-side `missed_withdraw_date`, log warning per `stop_time` malformato, `city` in `location_address` per ticket senza FK zona |
 
 ## Decisioni architetturali
+
+### Fix scheduler prune PendingAttachment (oc:8057)
+- `model:prune` richiede `--model` esplicito su `PendingAttachment` — senza il flag, i file temporanei caricati nell'editor Trix di Nova non vengono eliminati
+- `PendingAttachment` usa il trait `Prunable` (non `MassPrunable`): trigghera `pruning()` per-record che chiama `Storage::disk()->delete()` — i file fisici sono eliminati correttamente
+- Finestra di pruning: `created_at <= now()->subDays(1)` — hard-coded nel modello Nova vendor
+- Il primo run in produzione dopo il deploy eliminerà i file accumulati: fare un backup spot del filesystem prima
 
 ### Test suite (oc:7991)
 - DB di test `pap_test` separato da `pap` (sviluppo) — `TestCase::setUp()` abortisce con messaggio actionable se il DB è sbagliato

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Laravel\Nova\Fields\Attachments\PendingAttachment;
 
 class Kernel extends ConsoleKernel
 {
@@ -18,7 +19,9 @@ class Kernel extends ConsoleKernel
         // $schedule->command('inspire')->hourly();
         $schedule->command('horizon:snapshot')->everyFiveMinutes();
         $schedule->command('tickets:update-execute')->dailyAt('22:00');
-        $schedule->command('model:prune')->daily();
+        $schedule->command('model:prune', [
+            '--model' => [PendingAttachment::class],
+        ])->daily();
     }
 
     /**

--- a/docs/features/8057-fix-scheduler-prune-pending-attachment/notes.md
+++ b/docs/features/8057-fix-scheduler-prune-pending-attachment/notes.md
@@ -1,0 +1,19 @@
+> Ticket: oc:8057
+
+# Notes — [ersu] Fix scheduler model:prune — PendingAttachment Nova/Trix
+
+## Deviazioni dal piano
+Nessuna.
+
+## Bug trovati
+Nessuno aggiuntivo rispetto a quanto descritto nel ticket.
+
+## Decisioni
+- Verificato il sorgente `vendor/laravel/nova/src/Fields/Attachments/PendingAttachment.php`: il modello usa il trait `Prunable` (non `MassPrunable`), che trigghera `pruning()` per ogni record prima della DELETE. Il metodo `pruning()` chiama `Storage::disk($this->disk)->delete($this->attachment)` — i file fisici vengono eliminati correttamente insieme ai record DB.
+- Finestra di pruning: `created_at <= now()->subDays(1)`. Comportamento atteso e coerente con il flusso operativo (upload e invio immediato).
+- Il finding della challenge su `MassPrunable` è stato refutato dalla lettura del sorgente vendor.
+
+## Follow-up
+- Test automatico che verifichi l'esecuzione del prune (non incluso in questo ciclo per scope minimo)
+- Checklist pre-deploy produzione: run manuale in staging + backup spot del filesystem prima del primo run (eliminerà i file accumulati fino al deploy)
+- Restano aperti i finding 2-6 del ticket (validazione upload, test MIME, multi-ticket, `max_file_uploads`, `APP_URL`) — esclusi dallo scope di questo ciclo

--- a/docs/features/8057-fix-scheduler-prune-pending-attachment/overview.md
+++ b/docs/features/8057-fix-scheduler-prune-pending-attachment/overview.md
@@ -1,0 +1,27 @@
+> Ticket: oc:8057
+
+# [ersu] Fix scheduler model:prune — PendingAttachment Nova/Trix
+
+## Cosa cambia
+Lo scheduler notturno `model:prune` viene configurato per eliminare anche le righe in `nova_pending_field_attachments` e i file fisici associati caricati nell'editor Trix, che attualmente non vengono prunati.
+
+## Perché
+Il comando `model:prune` gira ogni notte alle 00:00 ma senza il flag `--model` su `PendingAttachment` di Nova. Nel tempo i file caricati nell'editor (immagini, PDF) si accumulano in `storage/app/public/` e le relative righe restano in `nova_pending_field_attachments`, riducendo lo spazio disco disponibile fino a causare fallimenti negli upload.
+
+## Requisiti
+- [ ] Aggiungere `--model` con `PendingAttachment::class` al comando `model:prune` nello scheduler
+- [ ] Il prune deve avvenire ogni notte (comportamento già presente, da mantenere)
+
+## Rischi
+- **Basso** — `PendingAttachment` è un modello Nova con logica `MassPrunable` già implementata dalla libreria; il flag `--model` la attiva senza modificare il comportamento delle altre prunable model già gestite dal comando senza flag.
+- **Nessun impatto sui file già inviati** — il prune elimina solo i record in stato "pending" (file caricati ma non ancora associati a un messaggio inviato); gli attachment già allegati alle risposte non sono toccati.
+
+## Out of scope
+- Validazione tipo/dimensione file nell'upload Trix
+- Assert MIME negli unit test esistenti
+- Gestione invio parziale su selezione multi-ticket
+- Configurazione `max_file_uploads` PHP
+- Dipendenza `APP_URL` per immagini inline
+
+## Moduli toccati
+- `app/Console/Kernel.php` — aggiunta opzione `--model` al comando `model:prune`

--- a/docs/features/8057-fix-scheduler-prune-pending-attachment/plan.md
+++ b/docs/features/8057-fix-scheduler-prune-pending-attachment/plan.md
@@ -1,0 +1,41 @@
+> Ticket: oc:8057
+
+# Plan — [ersu] Fix scheduler model:prune — PendingAttachment Nova/Trix
+
+## Repo coinvolti
+- **portapporta** (repo principale) — Custom, nessun submodule
+
+## Step 1 — Fix scheduler
+
+**File:** `app/Console/Kernel.php`
+
+Sostituire la riga:
+```php
+$schedule->command('model:prune')->daily();
+```
+con:
+```php
+$schedule->command('model:prune', [
+    '--model' => [\Laravel\Nova\Fields\Attachments\PendingAttachment::class],
+])->daily();
+```
+
+**Nota:** `PendingAttachment` usa il trait `Prunable` (non `MassPrunable`) con:
+- `prunable()` → scope `created_at <= now()->subDays(1)`
+- `pruning()` → `Storage::disk($this->disk)->delete($this->attachment)` (elimina il file fisico prima del DELETE DB)
+
+## Step 2 — Documentazione
+
+- Creare `docs/features/8057-fix-scheduler-prune-pending-attachment/notes.md`
+- Aggiornare `CLAUDE.md` (sezione "Feature disponibili" e "Decisioni architetturali")
+
+## Commit
+
+```
+fix(oc:8057): add --model PendingAttachment to model:prune scheduler
+```
+
+## Checklist pre-deploy produzione
+- [ ] Eseguire `php artisan model:prune --model="Laravel\Nova\Fields\Attachments\PendingAttachment"` manualmente in staging e verificare che i record `nova_pending_field_attachments` vecchi vengano eliminati
+- [ ] Verificare che i file fisici corrispondenti siano rimossi da `storage/app/public/`
+- [ ] Fare un backup spot del filesystem prima del primo run in produzione (il primo run eliminerà i file accumulati fino ad oggi)


### PR DESCRIPTION
## Summary
- Aggiunto `--model => [PendingAttachment::class]` al comando `model:prune` nello scheduler notturno (`app/Console/Kernel.php`)
- Il modello Nova usa il trait `Prunable` con hook `pruning()` che elimina il file fisico da disco prima del DELETE DB — i file temporanei Trix vengono ora ripuliti ogni notte dopo 24h
- Aggiornati `CLAUDE.md` e documentazione in `docs/features/8057-fix-scheduler-prune-pending-attachment/`

## Test plan
- [ ] Eseguire manualmente `php artisan model:prune --model="Laravel\Nova\Fields\Attachments\PendingAttachment"` in staging
- [ ] Verificare che i record in `nova_pending_field_attachments` più vecchi di 24h vengano eliminati
- [ ] Verificare che i file fisici corrispondenti siano rimossi da `storage/app/public/`
- [ ] Backup spot del filesystem prima del primo run in produzione

🤖 Generated with [Claude Code](https://claude.com/claude-code)