### PR TITLE
fix(oc:8058): ripristina campi contatto utente in Nova ed email ticket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,12 +48,19 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fix campi contatto utente assenti in Nova ed email ticket | oc:8058 | `app/Nova/Ticket.php`, `resources/views/emails/tickets/partials/user-form-fields.blade.php` | Ripristina Name/Email/BelongsTo/Phone in Nova; aggiunge email+nome account prima dei dati TARI nel partial email |
 | Fix scheduler model:prune PendingAttachment Nova/Trix | oc:8057 | `app/Console/Kernel.php` | Aggiunto `--model PendingAttachment` al prune notturno per eliminare file temporanei Trix accumulati |
 | Revisione test suite: db di test dedicato | oc:7991 | `tests/TestCase.php`, `phpunit.xml`, `app/Providers/RouteServiceProvider.php`, `.github/workflows/*.yml` | DB `pap_test` dedicato, guard anti-dev-db, throttle disabilitato in testing, CI su PostgreSQL 14+PostGIS |
 | Smistamento automatico segnalazioni Lunigiana | oc:7616 | `config/lunigiana.php`, `app/Models/Ticket.php`, `app/Http/Controllers/TicketController.php` | Duplica le email ticket verso urp@lunigianaambiente.it per le zone Lunigiana di ERSU |
 | Bug oc:7609 — bloccanti 3 e 4 backend | oc:8054 | `app/Http/Controllers/CalendarController.php`, `app/Http/Controllers/TicketController.php`, `app/Nova/Ticket.php`, `resources/views/emails/tickets/created.blade.php` | Validazione server-side `missed_withdraw_date`, log warning per `stop_time` malformato, `city` in `location_address` per ticket senza FK zona |
 
 ## Decisioni architetturali
+
+### Fix campi contatto utente in Nova ed email (oc:8058)
+- I 4 campi statici (`Name`, `Email`, `BelongsTo User`, `Phone`) sono wrappati in `if ($this->user)` in `_headerFields` — così gli altri campi dell'header restano visibili anche per ticket orfani
+- `->with(['user'])` aggiunto in `indexQuery` per prevenire N+1 con `BelongsTo::make('User')` visibile in index
+- Email e nome account nel partial `user-form-fields.blade.php` precedono i dati TARI dinamici (inline, senza header separatore) per tutti i formati (`br`, `table`, `paragraph`)
+- Test Nova: asserzioni su campi tradotti usano `__('Name')` / `__('Phone')` perché il locale del progetto è `it` (`__('Name')` → `'Nome'`)
 
 ### Fix scheduler prune PendingAttachment (oc:8057)
 - `model:prune` richiede `--model` esplicito su `PendingAttachment` — senza il flag, i file temporanei caricati nell'editor Trix di Nova non vengono eliminati

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -40,6 +40,14 @@ class Ticket extends Model
     {
         return $this->belongsTo(Company::class);
     }
+    public function resolvePhone(): ?string
+    {
+        if (filled($this->phone)) {
+            return $this->phone;
+        }
+        return $this->user?->phone_number ?? null;
+    }
+
     public function isLunigianaZone(): bool
     {
         return $this->zone_id !== null && in_array($this->zone_id, config('lunigiana.zones', []));

--- a/app/Nova/Ticket.php
+++ b/app/Nova/Ticket.php
@@ -157,7 +157,7 @@ class Ticket extends Resource
                 return $this->user->email;
             })->readonly();
             $fields[] = Text::make(__('Phone'), function () {
-                return $this->phone;
+                return $this->resolvePhone();
             })->onlyOnDetail()->readonly();
         }
         $this->_userFormDataFields($fields);
@@ -294,7 +294,9 @@ class Ticket extends Resource
         if (empty($schema)) {
             return;
         }
+        $staticNames = ['name', 'email', 'phone_number', 'phone'];
         $filtered = $user->filterFormSchemaExcludingTypes($schema, ['password', 'group']);
+        $filtered = array_values(array_filter($filtered, fn($f) => !in_array($f['name'] ?? '', $staticNames)));
         $formData = $user->form_data ?? [];
         foreach ($user->jsonFormReadOnlyFields($filtered, $formData) as $field) {
             $fields[] = $field;

--- a/app/Nova/Ticket.php
+++ b/app/Nova/Ticket.php
@@ -8,6 +8,7 @@ use App\Models\Ticket as TicketModel;
 use App\Nova\Actions\TicketAnswerViaMail;
 use App\Nova\Actions\TicketStatusAction;
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\URL;
 use Laravel\Nova\Fields\DateTime;
@@ -63,7 +64,8 @@ class Ticket extends Resource
      */
     public static function indexQuery(NovaRequest $request, $query)
     {
-        return $query->where('company_id', $request->user()->companyWhereAdmin->id);
+        return $query->where('company_id', $request->user()->companyWhereAdmin->id)
+                     ->with(['user']);
     }
 
     /**
@@ -146,6 +148,18 @@ class Ticket extends Resource
             }
         })->sortable()->readonly()->asHtml();
         $fields[] = DateTime::make(__('Created At'), 'created_at')->sortable()->readonly();
+        if ($this->user) {
+            $fields[] = Text::make(__('Name'), function () {
+                return $this->checkName($this->user->name);
+            })->readonly()->onlyOnDetail();
+            $fields[] = BelongsTo::make('User')->readonly();
+            $fields[] = Text::make('Email', function () {
+                return $this->user->email;
+            })->readonly();
+            $fields[] = Text::make(__('Phone'), function () {
+                return $this->phone;
+            })->onlyOnDetail()->readonly();
+        }
         $this->_userFormDataFields($fields);
         $fields[] =  Text::make(__('Status'), 'status', function ($res) {
             $translated = __($this->status->value);

--- a/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/notes.md
+++ b/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/notes.md
@@ -16,4 +16,13 @@
 
 ## Follow-up
 
-- I 3 cleanup non-bloccanti del code review oc:7599 rimangono aperti: telefono da `ticket.phone` vs `form_data` in Nova, fallback telefono in email, `filterOnlyFeSchema` non chiamato in Nova.
+- `filterOnlyFeSchema` non è ancora chiamato in Nova — rimane un cleanup non-bloccante del code review oc:7599.
+
+## Dedup + resolvePhone (aggiunto post-commit iniziale)
+
+Dopo il primo commit è emerso (screenshot) che nome, email e telefono erano mostrati due volte in Nova: una dai 4 campi statici, una dai campi dinamici `form_data` che includevano gli stessi field name. Stesso problema nel partial email.
+
+**Fix applicato in secondo commit:**
+- `Ticket::resolvePhone()` — metodo sul model, sorgente unica per la logica telefono (ticket->phone prima, user->phone_number come fallback). Condiviso da Nova e dal partial email.
+- `_userFormDataFields` in Nova — filtro `$staticNames = ['name', 'email', 'phone_number', 'phone']` applicato prima di creare i field dinamici.
+- `user-form-fields.blade.php` — stesso filtro `$staticNames` applicato dentro il foreach dei `$filtered`, più `$resolveTicketPhone` semplificato a chiamare `$ticket->resolvePhone()`.

--- a/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/notes.md
+++ b/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/notes.md
@@ -1,0 +1,19 @@
+> Ticket: oc:8058
+
+# Notes — [Bug] Campi contatto utente assenti in Nova ed email ticket
+
+## Deviazioni dal piano
+
+- **Test Nova con locale italiano**: le asserzioni sui campi tradotti (`__('Name')` → `'Nome'`, `__('Phone')` → `'Telefono'`) richiedono `__()` invece delle stringhe hardcoded in inglese. Il piano non lo specificava. Risolto usando `__('Name')` e `__('Phone')` nelle assertion.
+- **Test `headerFieldsSkipsStaticUserFieldsWhenUserIsNull`**: `user_id` è NOT NULL in DB, impossibile creare un ticket senza utente via factory. Soluzione: `$ticket->setRelation('user', null)` per simulare il caso orfano senza toccare il DB.
+- **Test `indexQueryEagerLoadsUser`**: `NovaRequest::create(...)` senza utente autenticato causa null pointer su `companyWhereAdmin`. Soluzione: `$request->setUserResolver(fn() => $admin)` con un utente che ha `admin_company_id` impostato.
+
+## Decisioni
+
+- I 4 campi statici sono wrappati in `if ($this->user)` invece di un early return globale — così gli altri campi dell'header (Ticket ID, Tipo, Data, Status, Zona) rimangono visibili anche per ticket orfani.
+- `->with(['user'])` aggiunto in `indexQuery` (non solo `detailQuery`) per prevenire N+1 con `BelongsTo::make('User')` visibile in index.
+- Le righe email + nome nel partial usano `__('Email')` / `__('Name')` per coerenza con il resto del template (già internazionalizzato).
+
+## Follow-up
+
+- I 3 cleanup non-bloccanti del code review oc:7599 rimangono aperti: telefono da `ticket.phone` vs `form_data` in Nova, fallback telefono in email, `filterOnlyFeSchema` non chiamato in Nova.

--- a/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/overview.md
+++ b/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/overview.md
@@ -1,0 +1,41 @@
+> Ticket: oc:8058
+
+# [Bug] Campi contatto utente assenti in Nova ed email ticket
+
+## Cosa cambia
+
+Il pannello dettaglio ticket in Nova torna a mostrare Name, Email, BelongsTo User e Phone ticket accanto ai campi TARI dinamici. Le email di notifica operatore tornano a includere email e nome account (dati di registrazione) come prime righe nella sezione "CHI HA SEGNALATO", prima dei dati TARI dinamici.
+
+## Perché
+
+Il commit `e42e206` (oc:7599) ha sostituito i 4 campi statici di Nova con la sola sezione dinamica `form_data`, invece di affiancarli. Il partial email `user-form-fields.blade.php` mostra solo i campi del form_json/form_data, omettendo le colonne `email` e `name` della tabella `users`. Gli operatori URP non possono più contattare il cittadino senza aprire manualmente il profilo utente.
+
+## Requisiti
+
+- [ ] Nova `app/Nova/Ticket.php`: ripristinare `use Laravel\Nova\Fields\BelongsTo` e i 4 campi statici in `_headerFields` — nell'ordine originale, prima di `_userFormDataFields`, wrappati in `if ($this->user)`
+  - `Text::make(__('Name'))` → `->readonly()->onlyOnDetail()`
+  - `BelongsTo::make('User')` → `->readonly()` (visibile anche in index)
+  - `Text::make('Email')` → `->readonly()` (visibile anche in index)
+  - `Text::make(__('Phone'))` → `->onlyOnDetail()->readonly()`
+- [ ] Nova `app/Nova/Ticket.php`: aggiungere `->with(['user'])` in `indexQuery` per prevenire N+1 con `BelongsTo` in index
+- [ ] Partial email `resources/views/emails/tickets/partials/user-form-fields.blade.php`: aggiungere email e nome account come prime righe inline (senza header separatore), prima dei dati TARI dinamici; skip se `$user` è null
+- [ ] Aggiungere test di regressione in `tests/Unit/Nova/TicketResourceTest.php` per verificare la presenza dei 4 campi statici nel pannello Nova
+- [ ] Aggiungere test di regressione in `tests/Feature/Emails/TicketEmailViewsTest.php` per verificare la presenza di email e nome account nel partial email
+
+## Rischi
+
+- **Doppio telefono in email**: se il campo `phone_number` è presente nello schema TARI, il telefono appare due volte (nella riga statica account e nella riga dinamica TARI). Non è un bloccante (i valori sono tipicamente identici) ed è out of scope per questo ticket.
+- **Nome account è un'email**: `checkName()` restituisce stringa vuota se `user->name` è un indirizzo email valido — questo era il comportamento originale, si ripristina invariato.
+
+## Out of scope
+
+- Cleanup: Nova mostra telefono da `form_data` invece di `ticket.phone`
+- Cleanup: telefono vuoto in email se `ticket.phone` assente ma profilo utente valorizzato
+- Cleanup: `filterOnlyFeSchema` non chiamato in Nova Ticket
+
+## Moduli toccati
+
+- `app/Nova/Ticket.php`
+- `resources/views/emails/tickets/partials/user-form-fields.blade.php`
+- `tests/Unit/Nova/TicketResourceTest.php`
+- `tests/Feature/Emails/TicketEmailViewsTest.php`

--- a/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/plan.md
+++ b/docs/features/8058-campi-contatto-utente-assenti-in-nova-ed-email-ticket/plan.md
@@ -1,0 +1,210 @@
+> Ticket: oc:8058
+
+# Plan — [Bug] Campi contatto utente assenti in Nova ed email ticket
+
+## Branch
+
+```bash
+git checkout -b fix/oc-8058-campi-contatto-utente-nova-email
+```
+
+---
+
+## Step 1 — Nova: eager load user in indexQuery
+
+**File:** `app/Nova/Ticket.php`
+
+Aggiungere `->with(['user'])` in `indexQuery` per prevenire N+1 quando `BelongsTo::make('User')` viene visualizzato nell'index.
+
+```php
+public static function indexQuery(NovaRequest $request, $query)
+{
+    return $query->where('company_id', $request->user()->companyWhereAdmin->id)
+                 ->with(['user']);
+}
+```
+
+---
+
+## Step 2 — Nova: ripristinare import BelongsTo e 4 campi statici
+
+**File:** `app/Nova/Ticket.php`
+
+**2a.** Aggiungere l'import mancante nella sezione `use`:
+
+```php
+use Laravel\Nova\Fields\BelongsTo;
+```
+
+**2b.** In `_headerFields`, inserire i 4 campi statici wrappati in `if ($this->user)`, prima della chiamata a `$this->_userFormDataFields($fields)`:
+
+```php
+$fields[] = DateTime::make(__('Created At'), 'created_at')->sortable()->readonly();
+if ($this->user) {
+    $fields[] = Text::make(__('Name'), function () {
+        return $this->checkName($this->user->name);
+    })->readonly()->onlyOnDetail();
+    $fields[] = BelongsTo::make('User')->readonly();
+    $fields[] = Text::make('Email', function () {
+        return $this->user->email;
+    })->readonly();
+    $fields[] = Text::make(__('Phone'), function () {
+        return $this->phone;
+    })->onlyOnDetail()->readonly();
+}
+$this->_userFormDataFields($fields);
+```
+
+---
+
+## Step 3 — Email partial: aggiungere righe statiche email e nome account
+
+**File:** `resources/views/emails/tickets/partials/user-form-fields.blade.php`
+
+Prima del blocco `@foreach ($rows as $row)` (che renderizza i dati TARI dinamici), aggiungere le righe fisse per email e nome dell'account. Le righe usano la stessa struttura condizionale dei tre formati già supportati (`br`, `table`, `paragraph`).
+
+Inserire dopo il blocco `@endphp` (riga 73) e prima di `@foreach ($rows as $row)`:
+
+```blade
+@if ($user)
+    @if ($format === 'paragraph')
+        <p><strong>{{ __('Email') }}:</strong> {{ $user->email ?: '-' }}</p>
+        <p><strong>{{ __('Name') }}:</strong> {{ $user->name ?: '-' }}</p>
+    @elseif ($format === 'table')
+        <tr>
+            <td width="130" style="padding:9px 14px;color:#777777;font-size:14px;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;vertical-align:top;">{{ __('Email') }}</td>
+            <td style="padding:9px 14px;font-size:14px;color:#333333;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;">{{ $user->email ?: '-' }}</td>
+        </tr>
+        <tr>
+            <td width="130" style="padding:9px 14px;color:#777777;font-size:14px;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;vertical-align:top;">{{ __('Name') }}</td>
+            <td style="padding:9px 14px;font-size:14px;color:#333333;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;">{{ $user->name ?: '-' }}</td>
+        </tr>
+    @else
+        <strong>{{ __('Email') }}:</strong> {{ $user->email ?: '-' }}<br>
+        <strong>{{ __('Name') }}:</strong> {{ $user->name ?: '-' }}<br>
+    @endif
+@endif
+```
+
+---
+
+## Step 4 — Test Nova: regressione campi statici
+
+**File:** `tests/Unit/Nova/TicketResourceTest.php`
+
+Aggiungere un test che verifica che `_headerFields` includa i 4 campi statici quando l'utente esiste. Usare `ReflectionMethod` come già fatto nei test esistenti.
+
+```php
+/** @test */
+public function headerFieldsIncludesStaticUserFields(): void
+{
+    $company = Company::factory()->create(['form_json' => null]);
+    $user = User::factory()->create(['app_company_id' => $company->id]);
+    $ticket = Ticket::factory()->create([
+        'company_id' => $company->id,
+        'user_id' => $user->id,
+    ]);
+
+    $resource = new TicketResource($ticket);
+    $fields = [];
+
+    $method = new ReflectionMethod(TicketResource::class, '_headerFields');
+    $method->setAccessible(true);
+    $method->invokeArgs($resource, [&$fields]);
+
+    $fieldNames = array_map(fn($f) => $f->name, $fields);
+    $this->assertContains('Name', $fieldNames);
+    $this->assertContains('Email', $fieldNames);
+    $this->assertContains('User', $fieldNames);
+    $this->assertContains('Phone', $fieldNames);
+}
+
+/** @test */
+public function headerFieldsSkipsStaticUserFieldsWhenUserIsNull(): void
+{
+    $company = Company::factory()->create(['form_json' => null]);
+    $ticket = Ticket::factory()->create([
+        'company_id' => $company->id,
+        'user_id' => null,
+    ]);
+
+    $resource = new TicketResource($ticket);
+    $fields = [];
+
+    $method = new ReflectionMethod(TicketResource::class, '_headerFields');
+    $method->setAccessible(true);
+    $method->invokeArgs($resource, [&$fields]);
+
+    $fieldNames = array_map(fn($f) => $f->name, $fields);
+    $this->assertNotContains('User', $fieldNames);
+    $this->assertNotContains('Email', $fieldNames);
+}
+```
+
+---
+
+## Step 5 — Test email: regressione email e nome account nel partial
+
+**File:** `tests/Feature/Emails/TicketEmailViewsTest.php`
+
+Aggiungere test che verificano la presenza di `user->email` e `user->name` nell'output HTML del partial, per tutti e tre i formati rilevanti.
+
+```php
+/** @test */
+public function partialRendersAccountEmailAndNameBeforeTariData(): void
+{
+    ['company' => $company, 'user' => $user, 'ticket' => $ticket] = $this->createTicketContext();
+
+    $html = view('emails.tickets.partials.user-form-fields', [
+        'user' => $user,
+        'company' => $company,
+        'ticket' => $ticket,
+        'format' => 'table',
+    ])->render();
+
+    $this->assertStringContainsString($user->email, $html);
+    $this->assertStringContainsString($user->name, $html);
+    // email e nome account devono apparire PRIMA dei dati TARI
+    $emailPos = strpos($html, $user->email);
+    $tariPos  = strpos($html, 'CF123456');
+    $this->assertLessThan($tariPos, $emailPos, 'Email account deve precedere i dati TARI');
+}
+
+/** @test */
+public function partialSkipsAccountFieldsWhenUserIsNull(): void
+{
+    $html = view('emails.tickets.partials.user-form-fields', [
+        'user' => null,
+        'company' => null,
+        'ticket' => null,
+        'format' => 'br',
+    ])->render();
+
+    $this->assertSame('', trim($html));
+}
+```
+
+---
+
+## Step 6 — Eseguire la test suite
+
+```bash
+docker exec php_portapporta php artisan config:clear
+docker exec php_portapporta php artisan test --filter="TicketResourceTest|TicketEmailViewsTest"
+```
+
+Tutti i test devono essere verdi prima di procedere al commit.
+
+---
+
+## Commit
+
+```
+fix(oc:8058): restore static user fields in Nova and email partial
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+## PR
+
+Aprire verso `develop` (branch di integrazione Webmapp).

--- a/resources/views/emails/tickets/partials/user-form-fields.blade.php
+++ b/resources/views/emails/tickets/partials/user-form-fields.blade.php
@@ -71,6 +71,24 @@
         }
     }
 @endphp
+@if ($user)
+    @if ($format === 'paragraph')
+        <p><strong>{{ __('Email') }}:</strong> {{ $user->email ?: '-' }}</p>
+        <p><strong>{{ __('Name') }}:</strong> {{ $user->name ?: '-' }}</p>
+    @elseif ($format === 'table')
+        <tr>
+            <td width="130" style="padding:9px 14px;color:#777777;font-size:14px;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;vertical-align:top;">{{ __('Email') }}</td>
+            <td style="padding:9px 14px;font-size:14px;color:#333333;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;">{{ $user->email ?: '-' }}</td>
+        </tr>
+        <tr>
+            <td width="130" style="padding:9px 14px;color:#777777;font-size:14px;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;vertical-align:top;">{{ __('Name') }}</td>
+            <td style="padding:9px 14px;font-size:14px;color:#333333;font-family:Arial,Helvetica,sans-serif;border-bottom:1px solid #eeeeee;">{{ $user->name ?: '-' }}</td>
+        </tr>
+    @else
+        <strong>{{ __('Email') }}:</strong> {{ $user->email ?: '-' }}<br>
+        <strong>{{ __('Name') }}:</strong> {{ $user->name ?: '-' }}<br>
+    @endif
+@endif
 @foreach ($rows as $row)
     @if ($format === 'paragraph')
         <p><strong>{{ __($row['label']) }}:</strong> {{ ($row['value'] ?? '') ?: '-' }}</p>

--- a/resources/views/emails/tickets/partials/user-form-fields.blade.php
+++ b/resources/views/emails/tickets/partials/user-form-fields.blade.php
@@ -17,17 +17,7 @@
             $formData = json_decode($formData, true) ?? [];
         }
     }
-    $resolveTicketPhone = function () use ($user, $formData, $ticket) {
-        if (!$user || !isset($ticket)) {
-            return $ticket->phone ?? null;
-        }
-        $userPhone = $user->phone_number ?? ($formData['phone_number'] ?? null);
-        $ticketPhone = $ticket->phone ?? null;
-        if ($userPhone !== null && $userPhone !== '' && (string) $userPhone === (string) $ticketPhone) {
-            return $userPhone;
-        }
-        return $ticketPhone;
-    };
+    $resolveTicketPhone = fn() => isset($ticket) ? $ticket->resolvePhone() : null;
     $isPhoneField = function ($name, $label) {
         if ($name === 'phone_number' || $name === 'phone') {
             return true;
@@ -42,8 +32,12 @@
             $filtered = method_exists($user, 'filterFormSchemaExcludingTypes')
                 ? $user->filterFormSchemaExcludingTypes($schema)
                 : array_values(array_filter($schema, fn($f) => !isset($f['only_fe']) || !$f['only_fe']));
+            $staticNames = ['name', 'email', 'phone_number', 'phone'];
             foreach ($filtered as $field) {
                 $name = $field['name'] ?? null;
+                if (in_array($name, $staticNames)) {
+                    continue;
+                }
                 $label = $field['label'] ?? ($name ? ucwords(str_replace('_', ' ', $name)) : null);
                 if ($label === null) {
                     continue;

--- a/tests/Feature/Emails/TicketEmailViewsTest.php
+++ b/tests/Feature/Emails/TicketEmailViewsTest.php
@@ -199,6 +199,38 @@ class TicketEmailViewsTest extends TestCase
     }
 
     /** @test */
+    public function partialRendersAccountEmailAndNameBeforeTariData(): void
+    {
+        ['company' => $company, 'user' => $user, 'ticket' => $ticket] = $this->createTicketContext();
+
+        $html = view('emails.tickets.partials.user-form-fields', [
+            'user' => $user,
+            'company' => $company,
+            'ticket' => $ticket,
+            'format' => 'table',
+        ])->render();
+
+        $this->assertStringContainsString($user->email, $html);
+        $this->assertStringContainsString($user->name, $html);
+        $emailPos = strpos($html, $user->email);
+        $tariPos  = strpos($html, 'CF123456');
+        $this->assertLessThan($tariPos, $emailPos, 'Email account deve precedere i dati TARI');
+    }
+
+    /** @test */
+    public function partialSkipsAccountFieldsWhenUserIsNull(): void
+    {
+        $html = view('emails.tickets.partials.user-form-fields', [
+            'user' => null,
+            'company' => null,
+            'ticket' => null,
+            'format' => 'br',
+        ])->render();
+
+        $this->assertSame('', trim($html));
+    }
+
+    /** @test */
     public function createdEmailUsesCompanyPrimaryColorInHeader(): void
     {
         $company = Company::factory()->create([

--- a/tests/Unit/Nova/TicketResourceTest.php
+++ b/tests/Unit/Nova/TicketResourceTest.php
@@ -94,4 +94,63 @@ class TicketResourceTest extends TestCase
 
         $this->assertEquals($zone->id, $ticket->zone->id);
     }
+
+    /** @test */
+    public function headerFieldsIncludesStaticUserFields(): void
+    {
+        $company = Company::factory()->create(['form_json' => null]);
+        $user = User::factory()->create(['app_company_id' => $company->id]);
+        $ticket = Ticket::factory()->create([
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+        ]);
+        $ticket->load('user');
+
+        $resource = new TicketResource($ticket);
+        $fields = [];
+
+        $method = new ReflectionMethod(TicketResource::class, '_headerFields');
+        $method->setAccessible(true);
+        $method->invokeArgs($resource, [&$fields]);
+
+        $fieldNames = array_map(fn($f) => $f->name, $fields);
+        $this->assertContains(__('Name'), $fieldNames);
+        $this->assertContains('Email', $fieldNames);
+        $this->assertContains('User', $fieldNames);
+        $this->assertContains(__('Phone'), $fieldNames);
+    }
+
+    /** @test */
+    public function headerFieldsSkipsStaticUserFieldsWhenUserIsNull(): void
+    {
+        $company = Company::factory()->create(['form_json' => null]);
+        $ticket = Ticket::factory()->create(['company_id' => $company->id]);
+        $ticket->setRelation('user', null);
+
+        $resource = new TicketResource($ticket);
+        $fields = [];
+
+        $method = new ReflectionMethod(TicketResource::class, '_headerFields');
+        $method->setAccessible(true);
+        $method->invokeArgs($resource, [&$fields]);
+
+        $fieldNames = array_map(fn($f) => $f->name, $fields);
+        $this->assertNotContains('User', $fieldNames);
+        $this->assertNotContains('Email', $fieldNames);
+    }
+
+    /** @test */
+    public function indexQueryEagerLoadsUser(): void
+    {
+        $company = Company::factory()->create();
+        $admin = User::factory()->create(['admin_company_id' => $company->id]);
+
+        $request = NovaRequest::create('/nova-api/tickets', 'GET');
+        $request->setUserResolver(fn() => $admin);
+
+        $query = Ticket::query();
+        $result = TicketResource::indexQuery($request, $query);
+
+        $this->assertArrayHasKey('user', $result->getEagerLoads());
+    }
 }


### PR DESCRIPTION
## Summary

- Ripristina i 4 campi statici utente (`Name`, `Email`, `BelongsTo User`, `Phone`) nella detail view Nova Ticket, rimossi per errore in oc:7599
- Aggiunge email e nome account nel partial email operatore (`user-form-fields.blade.php`) prima dei dati TARI dinamici
- Introduce `Ticket::resolvePhone()` come sorgente unica per la logica telefono (ticket→phone prima, user→phone_number come fallback), condivisa da Nova e dal partial email
- Aggiunge filtro `$staticNames` in `_userFormDataFields()` e nel partial blade per evitare duplicazione dei campi name/email/phone con quelli dinamici da `form_data`
- Aggiunge `->with(['user'])` in `indexQuery` per prevenire N+1 con `BelongsTo::make('User')` visibile in index
- 5 test di regressione nuovi (3 Unit Nova, 2 Feature Email)

## Test plan

- [ ] `docker exec php_portapporta php artisan test --filter="TicketResourceTest|TicketEmailViewsTest"` — 19 test verdi
- [ ] Nova detail view ticket: Name, Email, User (link), Phone visibili; dati TARI dinamici presenti senza duplicati
- [ ] Nova index ticket: colonna Email e link User visibili senza errori N+1
- [ ] Email operatore: email e nome account prima dei dati TARI; nessun duplicato nome/email/telefono

🤖 Generated with [Claude Code](https://claude.com/claude-code)