### PR TITLE
fix(oc:8099): fallback zone_id per app non aggiornate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fallback zone_id da geometry/address per app non aggiornate | oc:8099 | `app/Models/Zone.php`, `app/Http/Controllers/TicketController.php` | Deriva automaticamente zone_id pre-save via address.zone_id o PostGIS ST_Contains; garantisce forward Lunigiana anche da app vecchie |
 | Fix campi contatto utente assenti in Nova ed email ticket | oc:8058 | `app/Nova/Ticket.php`, `resources/views/emails/tickets/partials/user-form-fields.blade.php` | Ripristina Name/Email/BelongsTo/Phone in Nova; aggiunge email+nome account prima dei dati TARI nel partial email |
 | Fix scheduler model:prune PendingAttachment Nova/Trix | oc:8057 | `app/Console/Kernel.php` | Aggiunto `--model PendingAttachment` al prune notturno per eliminare file temporanei Trix accumulati |
 | Revisione test suite: db di test dedicato | oc:7991 | `tests/TestCase.php`, `phpunit.xml`, `app/Providers/RouteServiceProvider.php`, `.github/workflows/*.yml` | DB `pap_test` dedicato, guard anti-dev-db, throttle disabilitato in testing, CI su PostgreSQL 14+PostGIS |
@@ -55,6 +56,13 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 | Bug oc:7609 — bloccanti 3 e 4 backend | oc:8054 | `app/Http/Controllers/CalendarController.php`, `app/Http/Controllers/TicketController.php`, `app/Nova/Ticket.php`, `resources/views/emails/tickets/created.blade.php` | Validazione server-side `missed_withdraw_date`, log warning per `stop_time` malformato, `city` in `location_address` per ticket senza FK zona |
 
 ## Decisioni architetturali
+
+### Fallback zone_id da geometry/address (oc:8099)
+- `Zone::findByPoint(string $geometry, int $companyId): ?self` — primo metodo statico con raw SQL nel layer model (tutti gli altri sono nei controller). Primo utilizzo di `DB::selectOne` fuori dai controller — convenzione da seguire per query spaziali domain-specific.
+- `ST_SetSRID(?::geometry, 4326)` obbligatorio: geometry pre-save ha SRID=0 (`ST_GeomFromText` senza argomento), geometry post-save ha SRID=4326. Senza il force, `ST_Contains` ritorna `false` silenziosamente.
+- `ORDER BY ST_Area(geometry::geometry) ASC`: 27 coppie di zone ERSU si sovrappongono — l'ordinamento garantisce determinismo prendendo la zona più specifica.
+- Derivazione pre-save (non post-save): geometry e address_id sono già sull'oggetto Eloquent prima di `save()` — un solo write al DB.
+- `isCollectionInProgress` rimane fail-open per zone_id derivato: il blocco si attiva solo se `$request->exists('zone_id')` — comportamento intenzionale, non cambiato.
 
 ### Fix campi contatto utente in Nova ed email (oc:8058)
 - I 4 campi statici (`Name`, `Email`, `BelongsTo User`, `Phone`) sono wrappati in `if ($this->user)` in `_headerFields` — così gli altri campi dell'header restano visibili anche per ticket orfani

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -6,8 +6,10 @@ use App\Enums\TicketStatus;
 use App\Enums\TicketType;
 use App\Mail\TicketCreated;
 use App\Mail\TicketDeleted;
+use App\Models\Address;
 use App\Models\Company;
 use App\Models\Ticket;
+use App\Models\Zone;
 use App\Traits\GeojsonableTrait;
 use Exception;
 use Illuminate\Http\Request;
@@ -122,6 +124,9 @@ class TicketController extends Controller
                 }
             }
         }
+        if (is_null($ticket->zone_id)) {
+            $ticket->zone_id = $this->_deriveZoneId($ticket);
+        }
         $res = $ticket->save();
 
         // Send a notification email to company for the newly created ticket
@@ -214,6 +219,9 @@ class TicketController extends Controller
             $location_address .= $request->city;
         }
         $ticket->location_address = $location_address;
+        if (is_null($ticket->zone_id)) {
+            $ticket->zone_id = $this->_deriveZoneId($ticket);
+        }
         $res = $ticket->save();
 
         // Send a notification email to company for the newly created ticket
@@ -304,6 +312,9 @@ class TicketController extends Controller
             $location_address .= $request->city;
         }
         $ticket->location_address = $location_address;
+        if (is_null($ticket->zone_id)) {
+            $ticket->zone_id = $this->_deriveZoneId($ticket);
+        }
 
         // Attempt to save changes
         $res = $ticket->save();
@@ -345,7 +356,7 @@ class TicketController extends Controller
             return;
         }
         if (!$ticket->zone_id && $company->id === config('lunigiana.company_id')) {
-            Log::warning('ERSU ticket has no zone_id, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
+            Log::warning('ERSU ticket zone_id derivation failed, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
             return;
         }
         if ($ticket->isLunigianaZone()) {
@@ -361,6 +372,22 @@ class TicketController extends Controller
         else {
             Log::info('Ticket is not in a Lunigiana zone, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
         }
+    }
+
+    private function _deriveZoneId(Ticket $ticket): ?int
+    {
+        if ($ticket->address_id) {
+            $zoneId = Address::find($ticket->address_id)?->zone_id;
+            if ($zoneId) {
+                return $zoneId;
+            }
+        }
+
+        if ($ticket->geometry) {
+            return Zone::findByPoint($ticket->geometry, $ticket->company_id)?->id;
+        }
+
+        return null;
     }
 
     private function _geometryToLatLon($geometry)

--- a/app/Models/Zone.php
+++ b/app/Models/Zone.php
@@ -55,4 +55,16 @@ class Zone extends Model
     {
         return $this->hasMany(User::class);
     }
+
+    private const SRID_WGS84 = 4326;
+
+    public static function findByPoint(string $geometry, int $companyId): ?self
+    {
+        $result = DB::selectOne(
+            'SELECT id FROM zones WHERE company_id = ? AND geometry IS NOT NULL AND ST_Contains(geometry::geometry, ST_SetSRID(?::geometry, ' . self::SRID_WGS84 . ')) ORDER BY ST_Area(geometry::geometry) ASC LIMIT 1',
+            [$companyId, $geometry]
+        );
+
+        return $result ? self::find($result->id) : null;
+    }
 }

--- a/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/notes.md
+++ b/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/notes.md
@@ -1,0 +1,23 @@
+> Ticket: oc:8099
+
+# Notes — [ersu] Fallback zone_id in ticket store per app non aggiornate
+
+## Deviazioni dal piano
+
+- La derivazione è stata applicata anche a `v1update()`, non prevista nelle note del ticket originale ma approvata esplicitamente durante la Fase 2 del workflow.
+
+## Bug trovati
+
+- SRID mismatch pre/post-save: `ST_GeomFromText` senza SRID genera geometria con SRID=0, mentre le zone ERSU sono SRID=4326. Risolto con `ST_SetSRID(?::geometry, 4326)` in `Zone::findByPoint`. Scoperto durante la Challenge (Fase 3).
+
+## Decisioni
+
+- Derivazione pre-save (non post-save come suggerito dal ticket): evita un secondo write al DB mantenendo lo stesso risultato. La geometry e l'address_id sono già impostati sull'oggetto prima di `save()`.
+- `Zone::findByPoint` su model Zone (non metodo privato nel controller): scelta di riusabilità e testabilità, primo uso di raw SQL nel layer model — convenzione da riportare in CLAUDE.md.
+- `ORDER BY ST_Area(geometry::geometry) ASC`: 27 coppie di zone ERSU si sovrappongono in produzione (verificato), quindi l'ordinamento per area è necessario per determinismo.
+- Scope esteso a `v1update()` per coprire ticket pre-fix con `zone_id = null` che vengono aggiornati dopo il deploy.
+
+## Follow-up
+
+- `Zone::findByPoint` fa 2 query (SELECT id + self::find) — il chiamante usa solo `->id`. Candidato a refactoring in `?int` in un ciclo successivo.
+- `config/lunigiana.php` contiene ancora il TODO `// TODO: confermare lista definitiva zone_id con ERSU` — richiedere conferma ufficiale da ERSU e tracciare in un ticket dedicato.

--- a/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/overview.md
+++ b/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/overview.md
@@ -1,0 +1,50 @@
+> Ticket: oc:8099
+
+# [ersu] Fallback zone_id in ticket store per app non aggiornate
+
+## Cosa cambia
+
+Dopo il salvataggio di un ticket, se `zone_id` è null (client non lo ha mandato), il sistema lo deriva automaticamente — prima dall'`address.zone_id` se `address_id` è presente, poi tramite query PostGIS `ST_Contains` sulla tabella `zones`. Il `zone_id` derivato viene incluso nel primo `save()` del ticket (nessun secondo write). Questo garantisce che `forwardToLunigiana` riceva sempre un `zone_id` valorizzato quando è possibile derivarlo.
+
+## Perché
+
+Bug introdotto con oc:7616: `forwardToLunigiana` dipende da `$ticket->zone_id` impostato dal client mobile. App non aggiornate non mandano `zone_id` → il forward viene saltato silenziosamente anche per segnalazioni provenienti da zone Lunigiana. Il fix rende la derivazione di `zone_id` responsabilità del backend, non del client.
+
+## Requisiti
+
+- [ ] `Zone::findByPoint(string $geometry, int $companyId): ?self` — metodo statico su `Zone` che:
+  - accetta una stringa EWKB hex (formato nativo di `$ticket->geometry`) e un `company_id`
+  - usa `ST_SetSRID(?::geometry, 4326)` (non `?::geometry` nudo) per forzare SRID=4326 — la geometria pre-save ha SRID=0 (`ST_GeomFromText` senza argomento), quella post-save ha SRID=4326; senza il force il `ST_Contains` ritorna `false` silenziosamente
+  - esegue `ST_Contains(geometry::geometry, ST_SetSRID(?::geometry, 4326))` con query parametrizzata (no string interpolation)
+  - filtra per `company_id` per evitare di assegnare zone di altre company
+  - in caso di zone sovrapposte ordina per `ST_Area(geometry::geometry) ASC` e prende la più specifica (`LIMIT 1`)
+  - restituisce `null` se nessuna zona contiene il punto (fail-open)
+- [ ] Derivazione `zone_id` in `TicketController::store()` — prima del `$ticket->save()`, se `zone_id` è null:
+  1. se `$ticket->address_id` → `Address::find($ticket->address_id)?->zone_id`
+  2. se ancora null e `$ticket->geometry` → `Zone::findByPoint($ticket->geometry, $ticket->company_id)?->id`
+- [ ] Stessa derivazione in `TicketController::v1store()`, stessa posizione (pre-save)
+- [ ] Stessa derivazione in `TicketController::v1update()` — prima del `$ticket->save()`, se `$ticket->zone_id` è ancora null dopo il processing dei campi della request
+- [ ] Il guard in `forwardToLunigiana` (riga 347) rimane ma aggiorna il messaggio di log: non è più "app non aggiornata" ma "derivazione fallita" (nessun address né geometry disponibili, o punto fuori da tutte le zone ERSU)
+- [ ] Test Unit: `Zone::findByPoint()` — fixture zone sintetiche in DB, verifica: punto dentro zona, punto fuori, zone sovrapposte (prende la più piccola), company_id errato (null)
+- [ ] Test Feature: `POST /api/app/{id}/ticket/store` e `POST /api/v1/app/{id}/ticket/v1store` senza `zone_id` ma con `location` → ticket salvato con `zone_id` valorizzato
+
+## Rischi
+
+- **SRID pre-save vs post-save**: risolto con `ST_SetSRID(?::geometry, 4326)` in `Zone::findByPoint`. Il test Unit deve coprire entrambi i casi (geometria con SRID=0 e con SRID=4326) per garantire che il metodo funzioni sia da `store()`/`v1store()` (pre-save, SRID=0) sia da `v1update()` (da DB, SRID=4326).
+- **Address con zone_id null**: il caso 1 può restituire null anche con `address_id` presente — il caso 2 entra in cascata. Questo è il comportamento atteso ma va coperto dai test.
+- **Performance**: `ST_Contains` su 40 zone ERSU è trascurabile. Se in futuro il numero di zone cresce significativamente, un indice spaziale GIST su `zones.geometry` sarà necessario. Non richiesto ora.
+- **v1update con ticket pre-fix**: ticket creati prima di questo deploy hanno `zone_id = null` in DB. Al primo `v1update` successivo il fallback tenterà la derivazione — se il ticket ha geometry, verrà valorizzato. Se non ha né address né geometry (ticket molto vecchi), rimane null. Nessun rischio di regressione.
+
+## Out of scope
+
+- Applicare il fallback a company diverse da ERSU — la logica di derivazione è universale, ma il forward Lunigiana è solo ERSU; non si introduce logica company-specifica nel fallback stesso
+- Backfill dei ticket esistenti con `zone_id = null` — operazione separata se necessaria
+- Validazione `isCollectionInProgress` sul `zone_id` derivato — fail-open per design: se il client non ha mandato `zone_id` esplicitamente, il blocco raccolta in corso non si attiva
+- Refactor dell'inversione lon/lat tra `store()` e `v1store()` — bug pre-esistente, fuori scope
+
+## Moduli toccati
+
+- `app/Models/Zone.php` — aggiunto `Zone::findByPoint(string $geometry, int $companyId): ?self`
+- `app/Http/Controllers/TicketController.php` — logica derivazione `zone_id` in `store()`, `v1store()`, `v1update()`; aggiornamento messaggio log in `forwardToLunigiana`
+- `tests/Unit/ZoneFindByPointTest.php` — nuovo file
+- `tests/Feature/Api/ApiTicketTest.php` — nuovi test casi zone_id derivato

--- a/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/plan.md
+++ b/docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/plan.md
@@ -1,0 +1,164 @@
+> Ticket: oc:8099
+
+# Plan — [ersu] Fallback zone_id in ticket store per app non aggiornate
+
+## Task 1 — `Zone::findByPoint()` su `app/Models/Zone.php`
+
+Aggiungere `use Illuminate\Support\Facades\DB;` agli import (già presente nel file).
+
+Aggiungere il metodo statico alla classe `Zone`:
+
+```php
+public static function findByPoint(string $geometry, int $companyId): ?self
+{
+    $result = DB::selectOne(
+        'SELECT id FROM zones WHERE company_id = ? AND geometry IS NOT NULL AND ST_Contains(geometry::geometry, ST_SetSRID(?::geometry, 4326)) ORDER BY ST_Area(geometry::geometry) ASC LIMIT 1',
+        [$companyId, $geometry]
+    );
+
+    return $result ? self::find($result->id) : null;
+}
+```
+
+**Nota SRID:** `ST_SetSRID(?::geometry, 4326)` gestisce sia geometrie pre-save (SRID=0, da `ST_GeomFromText` senza argomento) sia post-save (SRID=4326, da Eloquent).
+
+---
+
+## Task 2 — Helper privato `_deriveZoneId()` su `TicketController`
+
+Aggiungere i due import mancanti in testa al file:
+```php
+use App\Models\Address;
+use App\Models\Zone;
+```
+
+Aggiungere il metodo privato alla classe `TicketController`:
+
+```php
+private function _deriveZoneId(Ticket $ticket): ?int
+{
+    if ($ticket->address_id) {
+        $zoneId = Address::find($ticket->address_id)?->zone_id;
+        if ($zoneId) {
+            return $zoneId;
+        }
+    }
+
+    if ($ticket->geometry) {
+        return Zone::findByPoint($ticket->geometry, $ticket->company_id)?->id;
+    }
+
+    return null;
+}
+```
+
+---
+
+## Task 3 — Derivazione in `store()`
+
+In `TicketController::store()`, inserire il blocco di derivazione **dopo** l'assegnazione di tutti i campi da request e **prima** di `$res = $ticket->save()` (attualmente riga ~125):
+
+```php
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+---
+
+## Task 4 — Derivazione in `v1store()`
+
+In `TicketController::v1store()`, inserire lo stesso blocco **dopo** l'assegnazione di `$ticket->location_address` e **prima** di `$res = $ticket->save()` (attualmente riga ~217):
+
+```php
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+---
+
+## Task 5 — Derivazione in `v1update()`
+
+In `TicketController::v1update()`, inserire lo stesso blocco **dopo** il blocco di processing dei campi della request e **prima** di `$ticket->save()`:
+
+```php
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+---
+
+## Task 6 — Aggiornamento log in `forwardToLunigiana()`
+
+Modificare il messaggio di warning alla riga 348 da:
+```php
+Log::warning('ERSU ticket has no zone_id, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
+```
+a:
+```php
+Log::warning('ERSU ticket zone_id derivation failed, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
+```
+
+---
+
+## Task 7 — Test Unit: `tests/Unit/ZoneFindByPointTest.php`
+
+Creare il file. Il test usa `RefreshDatabase` e fixture sintetiche. La `ZoneFactory` esistente usa già una geometria MultiPolygon sintetica intorno a `lon 10-11, lat 45-46` — costruire i punti test coerentemente.
+
+Casi da coprire:
+1. **Punto dentro la zona** — `POINT(10.5 45.5)` (dentro il multipolygon della factory), company corretta → ritorna la zona
+2. **Punto fuori da tutte le zone** — `POINT(0 0)`, company corretta → ritorna `null`
+3. **Company_id errato** — punto dentro, company sbagliata → ritorna `null`
+4. **Zone sovrapposte** — due zone con geometry diversa che si sovrappongono, punto nell'area comune → ritorna quella con area minore
+5. **SRID=0 pre-save** — geometria costruita con `ST_GeomFromText('POINT(10.5 45.5)')` (SRID=0) → ritorna la zona (verifica che `ST_SetSRID` funzioni)
+6. **SRID=4326 post-save** — geometria EWKB letta da un record Ticket salvato in DB → ritorna la zona
+
+Per il caso 5, costruire la geometria SRID=0 via:
+```php
+$geomSrid0 = DB::selectOne("SELECT ST_GeomFromText('POINT(10.5 45.5)') AS g")->g;
+```
+
+Per il caso 6, salvare un ticket con `geometry` standard e usare `$ticket->fresh()->geometry`.
+
+---
+
+## Task 8 — Test Feature: `tests/Feature/Api/ApiTicketTest.php`
+
+Aggiungere i seguenti test alla classe esistente (stile `RefreshDatabase` + `WithoutMiddleware` già presenti):
+
+**Test A — `store()` senza zone_id, con location dentro una zona:**
+```
+POST api/c/{company_id}/ticket
+body: { ticket_type: 'info', location: [45.5, 10.5] }
+```
+- Creare una zona ERSU con geometry che contenga il punto
+- Asserire che il ticket in DB abbia `zone_id` valorizzato con l'ID della zona
+
+**Test B — `v1store()` senza zone_id, con location dentro una zona:**
+```
+POST api/v1/c/{company_id}/ticket
+body: { ticket_type: 'info', location: [10.5, 45.5] }
+```
+- Stessa logica del Test A (v1store usa lon/lat nell'ordine inverso rispetto a store)
+
+**Test C — `store()` senza zone_id e location fuori da tutte le zone:**
+- Asserire che il ticket in DB abbia `zone_id = null` (fail-open)
+
+**Test D — `store()` con address_id che ha zone_id:**
+- Creare un Address con `zone_id` valorizzato
+- Fare store senza `zone_id` ma con `address_id`
+- Asserire che `ticket->zone_id` corrisponda a `address->zone_id`
+
+---
+
+## Commit
+
+```
+fix(oc:8099): fallback zone_id pre-save per app non aggiornate
+```
+
+Includere: `app/Models/Zone.php`, `app/Http/Controllers/TicketController.php`, `tests/Unit/ZoneFindByPointTest.php`, `tests/Feature/Api/ApiTicketTest.php`, `docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/`.
+
+PR verso `develop`.

--- a/tests/Feature/Api/ApiTicketTest.php
+++ b/tests/Feature/Api/ApiTicketTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature\Api;
 
+use App\Models\Address;
 use App\Models\Company;
 use App\Models\Ticket;
 use App\Models\TrashType;
 use App\Models\User;
+use App\Models\Zone;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -174,5 +176,101 @@ class ApiTicketTest extends TestCase
         $this->assertEquals($image, $data_out['image']);
         $ticket = Ticket::find($data_out['id']);
         $this->assertEquals($image, $ticket->image);
+    }
+
+    // -----------------------------------------------------------------------
+    // zone_id fallback derivation (oc:8099)
+    // -----------------------------------------------------------------------
+
+    private function makeZoneContainingPoint(int $companyId): Zone
+    {
+        // Polygon covering lon 10-11, lat 45-46 (contains POINT(10.5 45.5))
+        $geometry = DB::selectOne(
+            "SELECT ST_GeomFromText('MULTIPOLYGON(((10 45, 11 45, 11 46, 10 46, 10 45)))', 4326) AS g"
+        )->g;
+
+        return Zone::create([
+            'company_id' => $companyId,
+            'comune'     => 'TestComune',
+            'label'      => 'Test Zone',
+            'url'        => 'http://test.example',
+            'geometry'   => $geometry,
+        ]);
+    }
+
+    /** @test */
+    public function store_derives_zone_id_from_location_when_not_provided(): void
+    {
+        $company = Company::factory()->create();
+        $zone = $this->makeZoneContainingPoint($company->id);
+        Sanctum::actingAs(User::factory()->create(), ['*']);
+
+        // store() expects location as [lat, lon]
+        $response = $this->post("api/c/{$company->id}/ticket", [
+            'ticket_type' => 'info',
+            'location'    => [45.5, 10.5],
+        ]);
+
+        $this->assertSame(200, $response->status());
+        $ticket = Ticket::find($response->json('data.id'));
+        $this->assertEquals($zone->id, $ticket->zone_id);
+    }
+
+    /** @test */
+    public function v1store_derives_zone_id_from_location_when_not_provided(): void
+    {
+        $company = Company::factory()->create();
+        $zone = $this->makeZoneContainingPoint($company->id);
+        Sanctum::actingAs(User::factory()->create(), ['*']);
+
+        // v1store() uses POINT(location[0] location[1]) — pass [lon, lat]
+        $response = $this->post("api/v1/c/{$company->id}/ticket", [
+            'ticket_type' => 'info',
+            'location'    => [10.5, 45.5],
+        ]);
+
+        $this->assertSame(200, $response->status());
+        $ticket = Ticket::find($response->json('data.id'));
+        $this->assertEquals($zone->id, $ticket->zone_id);
+    }
+
+    /** @test */
+    public function store_zone_id_remains_null_when_location_outside_all_zones(): void
+    {
+        $company = Company::factory()->create();
+        $this->makeZoneContainingPoint($company->id);
+        Sanctum::actingAs(User::factory()->create(), ['*']);
+
+        $response = $this->post("api/c/{$company->id}/ticket", [
+            'ticket_type' => 'info',
+            'location'    => [0.0, 0.0],
+        ]);
+
+        $this->assertSame(200, $response->status());
+        $ticket = Ticket::find($response->json('data.id'));
+        $this->assertNull($ticket->zone_id);
+    }
+
+    /** @test */
+    public function store_derives_zone_id_from_address_when_address_id_provided(): void
+    {
+        $company = Company::factory()->create();
+        $zone = $this->makeZoneContainingPoint($company->id);
+        $user = User::factory()->create();
+        $address = Address::create([
+            'user_id' => $user->id,
+            'zone_id' => $zone->id,
+            'address' => 'Via Test 1',
+        ]);
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->post("api/c/{$company->id}/ticket", [
+            'ticket_type' => 'info',
+            'address_id'  => $address->id,
+        ]);
+
+        $this->assertSame(200, $response->status());
+        $ticket = Ticket::find($response->json('data.id'));
+        $this->assertEquals($zone->id, $ticket->zone_id);
     }
 }

--- a/tests/Unit/ZoneFindByPointTest.php
+++ b/tests/Unit/ZoneFindByPointTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Company;
+use App\Models\Zone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ZoneFindByPointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->company = Company::factory()->create();
+    }
+
+    private function makeZoneWithPolygon(array $coords, Company $company = null): Zone
+    {
+        $c = $company ?? $this->company;
+        $wkt = 'MULTIPOLYGON(((' . implode(', ', array_map(fn($p) => "{$p[0]} {$p[1]}", $coords)) . ')))';
+        $geometry = DB::selectOne("SELECT ST_GeomFromText(?, 4326) AS g", [$wkt])->g;
+
+        return Zone::create([
+            'company_id' => $c->id,
+            'comune'     => 'Test',
+            'label'      => 'Test Zone',
+            'url'        => 'http://test.example',
+            'geometry'   => $geometry,
+        ]);
+    }
+
+    private function pointGeomSrid0(float $lon, float $lat): string
+    {
+        return DB::selectOne("SELECT ST_GeomFromText('POINT($lon $lat)') AS g")->g;
+    }
+
+    private function pointGeomSrid4326(float $lon, float $lat): string
+    {
+        return DB::selectOne("SELECT ST_GeomFromText('POINT($lon $lat)', 4326) AS g")->g;
+    }
+
+    /** @test */
+    public function returns_zone_when_point_is_inside(): void
+    {
+        $zone = $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+
+        $result = Zone::findByPoint($this->pointGeomSrid4326(10.5, 45.5), $this->company->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals($zone->id, $result->id);
+    }
+
+    /** @test */
+    public function returns_null_when_point_is_outside_all_zones(): void
+    {
+        $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+
+        $result = Zone::findByPoint($this->pointGeomSrid4326(0.0, 0.0), $this->company->id);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function returns_null_when_company_id_does_not_match(): void
+    {
+        $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+        $otherCompany = Company::factory()->create();
+
+        $result = Zone::findByPoint($this->pointGeomSrid4326(10.5, 45.5), $otherCompany->id);
+
+        $this->assertNull($result);
+    }
+
+    /** @test */
+    public function returns_smallest_zone_when_zones_overlap(): void
+    {
+        // Large zone covering 10-11, 45-46
+        $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+        // Small zone covering only 10.4-10.6, 45.4-45.6 (subset of large)
+        $smallZone = $this->makeZoneWithPolygon([
+            [10.4, 45.4], [10.6, 45.4], [10.6, 45.6], [10.4, 45.6], [10.4, 45.4],
+        ]);
+
+        $result = Zone::findByPoint($this->pointGeomSrid4326(10.5, 45.5), $this->company->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals($smallZone->id, $result->id);
+    }
+
+    /** @test */
+    public function accepts_srid_0_geometry_pre_save(): void
+    {
+        $zone = $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+
+        // Simulates $ticket->geometry before save (ST_GeomFromText without SRID → SRID=0)
+        $geomSrid0 = $this->pointGeomSrid0(10.5, 45.5);
+
+        $result = Zone::findByPoint($geomSrid0, $this->company->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals($zone->id, $result->id);
+    }
+
+    /** @test */
+    public function accepts_srid_4326_geometry_post_save(): void
+    {
+        $zone = $this->makeZoneWithPolygon([
+            [10.0, 45.0], [11.0, 45.0], [11.0, 46.0], [10.0, 46.0], [10.0, 45.0],
+        ]);
+
+        $geomSrid4326 = $this->pointGeomSrid4326(10.5, 45.5);
+
+        $result = Zone::findByPoint($geomSrid4326, $this->company->id);
+
+        $this->assertNotNull($result);
+        $this->assertEquals($zone->id, $result->id);
+    }
+}


### PR DESCRIPTION
## Summary

- Aggiunto `Zone::findByPoint(string $geometry, int $companyId): ?self` con query PostGIS parametrizzata e `ST_SetSRID(?::geometry, 4326)` per compatibilità SRID pre/post-save
- Derivazione automatica `zone_id` pre-save in `store()`, `v1store()`, `v1update()` — cascata: `address.zone_id` → `ST_Contains` su geometry
- Fix forward Lunigiana silenzioso per app non aggiornate che non mandano `zone_id`

## Test plan

- [ ] `php artisan test --filter="ZoneFindByPointTest"` — 6 casi Unit (dentro/fuori/company errata/zone sovrapposte/SRID=0/SRID=4326)
- [ ] `php artisan test --filter="ApiTicketTest"` — 4 nuovi casi Feature (store/v1store/fuori zona/address fallback)
- [ ] `php artisan test` — suite completa, nessuna regressione (245 test)
- [ ] Verificare in staging che un ticket ERSU senza `zone_id` riceva correttamente il forward Lunigiana

## Note

Refs: oc:8099
Docs: `docs/features/8099-fallback-zone-id-ticket-store-app-non-aggiornate/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)