### PR TITLE
feat(oc:8111): invio mail Lunigiana esclusivo con fallback su company

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -129,16 +129,9 @@ class TicketController extends Controller
         }
         $res = $ticket->save();
 
-        // Send a notification email to company for the newly created ticket
         if ($res) {
             $company = Company::find($request->id);
-            if ($company->ticket_email) {
-                foreach (explode(',', $company->ticket_email) as $recipient) {
-                    Mail::to($recipient)->send(new TicketCreated($ticket, $company));
-                }
-            }
-            // LUNIGIANA_FORWARD
-            $this->forwardToLunigiana($ticket, $company, new TicketCreated($ticket, $company));
+            $this->sendTicketNotification($ticket, $company, new TicketCreated($ticket, $company));
         }
 
         // Response
@@ -224,16 +217,9 @@ class TicketController extends Controller
         }
         $res = $ticket->save();
 
-        // Send a notification email to company for the newly created ticket
         if ($res) {
             $company = Company::find($request->id);
-            if ($company->ticket_email) {
-                foreach (explode(',', $company->ticket_email) as $recipient) {
-                    Mail::to($recipient)->send(new TicketCreated($ticket, $company));
-                }
-            }
-            // LUNIGIANA_FORWARD
-            $this->forwardToLunigiana($ticket, $company, new TicketCreated($ticket, $company));
+            $this->sendTicketNotification($ticket, $company, new TicketCreated($ticket, $company));
         }
 
         // Response
@@ -321,15 +307,9 @@ class TicketController extends Controller
 
         // Response
         if ($res) {
-            if($ticket->status == TicketStatus::Deleted){
+            if ($ticket->status == TicketStatus::Deleted) {
                 $company = Company::find($ticket->company_id);
-                if ($company->ticket_email) {
-                    foreach (explode(',', $company->ticket_email) as $recipient) {
-                        Mail::to($recipient)->send(new TicketDeleted($ticket, $company));
-                    }
-                }
-                // LUNIGIANA_FORWARD
-                $this->forwardToLunigiana($ticket, $company, new TicketDeleted($ticket, $company));
+                $this->sendTicketNotification($ticket, $company, new TicketDeleted($ticket, $company));
             }
             return $this->sendResponse($ticket, 'Ticket updated.');
         } else {
@@ -349,28 +329,52 @@ class TicketController extends Controller
         //
     }
 
-    private function forwardToLunigiana(Ticket $ticket, Company $company, \Illuminate\Mail\Mailable $mailable): void
+    // NOTE: non riusare la stessa istanza $mailable tra invii multipli —
+    // SymfonyMessage è mutabile e può portare stato residuo dal send precedente.
+    private function sendTicketNotification(Ticket $ticket, Company $company, \Illuminate\Mail\Mailable $mailable): void
     {
         if (!config('lunigiana.enabled')) {
-            Log::warning('Lunigiana forwarding is disabled', ['ticket_id' => $ticket->id]);
+            Log::info('Lunigiana forwarding disabled, sending to company', ['ticket_id' => $ticket->id]);
+            $this->sendToCompany($company, $mailable);
             return;
         }
+
         if (!$ticket->zone_id && $company->id === config('lunigiana.company_id')) {
-            Log::warning('ERSU ticket zone_id derivation failed, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
+            Log::warning('ERSU ticket zone_id derivation failed, falling back to company email', ['ticket_id' => $ticket->id]);
+            $this->sendToCompany($company, $mailable);
             return;
         }
-        if ($ticket->isLunigianaZone()) {
-            foreach (explode(',', config('lunigiana.email')) as $recipient) {
-                try {
-                    Log::info('Sending Lunigiana email to ' . $recipient, ['ticket_id' => $ticket->id]);
-                    Mail::to($recipient)->send($mailable);
-                } catch (\Exception $e) {
-                    Log::warning('Lunigiana forward failed', ['ticket_id' => $ticket->id, 'recipient' => $recipient, 'error' => $e->getMessage()]);
-                }
-            }
+
+        if (!$ticket->isLunigianaZone()) {
+            $this->sendToCompany($company, $mailable);
+            return;
         }
-        else {
-            Log::info('Ticket is not in a Lunigiana zone, Lunigiana forward skipped', ['ticket_id' => $ticket->id]);
+
+        try {
+            $this->sendLunigianaEmails($ticket, $mailable);
+        } catch (\Exception $e) {
+            Log::error('Lunigiana forward failed, falling back to company email', [
+                'ticket_id' => $ticket->id,
+                'error'     => $e->getMessage(),
+            ]);
+            $this->sendToCompany($company, $mailable);
+        }
+    }
+
+    protected function sendLunigianaEmails(Ticket $ticket, \Illuminate\Mail\Mailable $mailable): void
+    {
+        foreach (explode(',', config('lunigiana.email')) as $recipient) {
+            Log::info('Sending Lunigiana email to ' . trim($recipient), ['ticket_id' => $ticket->id]);
+            Mail::to(trim($recipient))->send($mailable);
+        }
+    }
+
+    private function sendToCompany(Company $company, \Illuminate\Mail\Mailable $mailable): void
+    {
+        if ($company->ticket_email) {
+            foreach (explode(',', $company->ticket_email) as $recipient) {
+                Mail::to(trim($recipient))->send($mailable);
+            }
         }
     }
 

--- a/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/notes.md
+++ b/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/notes.md
@@ -1,0 +1,42 @@
+> Ticket: oc:8111
+
+# Notes — Modifica invio mail Lunigiana: esclusivo con fallback su mail company
+
+## Deviazioni dal piano
+
+### per-recipient try/catch → protected method + try/catch esterno singolo
+
+Il piano (Task 3) prevedeva un loop `foreach` con try/catch **per-recipient** dentro `sendTicketNotification`, che tentava tutti i destinatari Lunigiana prima di decidere il fallback. L'implementazione ha estratto il loop in `sendLunigianaEmails()` (protected) con un singolo try/catch esterno in `sendTicketNotification`.
+
+**Motivazione:** `sendLunigianaEmails` doveva essere `protected` (non `private`) per permettere il mock via Mockery in `testV1StoreLunigianaFailureFallsBackToCompany`. Con il try/catch interno per-recipient, mockare l'intera funzione e farla lanciare eccezione non era possibile in modo pulito.
+
+**Impatto pratico:** In produzione c'è un solo destinatario Lunigiana (`urp@lunigianaambiente.it`), quindi il comportamento è identico. Con una lista comma-separated di più destinatari, la semantica diverge: al primo SMTP failure gli altri destinatari vengono saltati e scatta il fallback. Questa semantica è conforme al requisito ("se anche un solo destinatario fallisce → fallback") ma non tenta gli altri destinatari prima del fallback.
+
+## Decisioni
+
+- `sendLunigianaEmails` è `protected` per ragioni di testabilità (mock Mockery), non per design architetturale. `sendToCompany` resta `private`. L'asimmetria è intenzionale e documentata qui.
+- Il Mailable viene istanziato dal call site e passato già costruito. Il commento nel codice avverte di non riusare la stessa istanza — rischio accettato e mitigato con documentazione, non risolto strutturalmente (out of scope).
+
+## Follow-up
+
+- **SMTP asincrono (priorità bassa):** tutti i `Mail::send()` nel controller sono sincroni (blocking). Sotto carico elevato con SMTP Lunigiana lento, i worker PHP-FPM possono esaurirsi prima del fallback. Il fix richiede refactor verso queue (es. `Mail::to()->queue()`) — out of scope per oc:8111.
+- **Magic strings nei test:** `'lunigiana@test.it'` e `'test@example.com'` sono hardcoded nelle asserzioni `hasTo()`. Se `createCompany()` in `FeatureTestV2UtilsFunctions` cambia la `ticket_email` di default, le asserzioni si rompono. Da estrarre in costanti in un prossimo refactor dei test.
+
+## Procedura di rollback
+
+In caso di regressione in produzione dopo il deploy:
+
+1. Ripristinare nel call site `store()` (~riga 132) il blocco:
+   ```php
+   if ($company->ticket_email) {
+       foreach (explode(',', $company->ticket_email) as $recipient) {
+           Mail::to($recipient)->send(new TicketCreated($ticket, $company));
+       }
+   }
+   $this->forwardToLunigiana($ticket, $company, new TicketCreated($ticket, $company));
+   ```
+2. Ripetere per `v1store()` e `v1update()`.
+3. Ripristinare il metodo `forwardToLunigiana()` (vedere commit precedente).
+4. Rimuovere `sendTicketNotification()`, `sendLunigianaEmails()`, `sendToCompany()`.
+
+Il kill switch via env (`LUNIGIANA_FORWARD_ENABLED=false`) continua a funzionare anche con oc:8111 attivo: invia alla company come prima.

--- a/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/overview.md
+++ b/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/overview.md
@@ -1,0 +1,43 @@
+> Ticket: oc:8111
+
+# Modifica invio mail Lunigiana: esclusivo con fallback su mail company
+
+## Cosa cambia
+
+Per i ticket nelle zone Lunigiana di ERSU, le notifiche email vengono ora inviate **esclusivamente** ai destinatari Lunigiana configurati, senza più duplicare la notifica alla mail di default della company. Se anche un solo destinatario Lunigiana fallisce, l'invio cade in fallback sulla mail company. Tutta la logica di routing è centralizzata in un nuovo metodo privato `sendTicketNotification()`. Stessa logica per `TicketCreated` e `TicketDeleted`.
+
+## Perché
+
+Attualmente la notifica viene inviata sia alla company sia a Lunigiana, causando duplicazione delle email per i ticket Lunigiana. Il cliente vuole un comportamento esclusivo (solo Lunigiana), mantenendo la company come rete di sicurezza in caso di errore.
+
+## Requisiti
+
+- [ ] Introdurre il metodo privato `sendTicketNotification(Ticket, Company, Mailable)` che centralizza tutta la logica di routing email, sostituendo il doppio blocco attuale (company + `forwardToLunigiana`)
+- [ ] Per ticket in zona Lunigiana con forwarding abilitato: inviare la mail **solo** ai destinatari Lunigiana, non alla company
+- [ ] Se anche un solo destinatario Lunigiana solleva un'eccezione durante l'invio: loggare a livello `error` e inviare la mail a tutti i destinatari company come fallback
+- [ ] Quando `LUNIGIANA_FORWARD_ENABLED=false`: inviare la mail alla company (graceful degradation); loggare a `Log::info` (non `warning`) perché è una configurazione intenzionale
+- [ ] Quando il ticket è ERSU ma `zone_id` non è derivabile: inviare la mail alla company come fallback sicuro
+- [ ] I 3 call site (`store`, `v1store`, `v1update`) chiamano solo `sendTicketNotification` — nessuna logica di routing fuori dal metodo
+- [ ] Il Mailable viene istanziato dal call site e passato già costruito; aggiungere un commento nel metodo che avverte di non riusare la stessa istanza tra invii multipli
+- [ ] La logica si applica sia a `TicketCreated` (`store`, `v1store`) sia a `TicketDeleted` (`v1update`)
+- [ ] Aggiungere test PHPUnit per: (1) zona Lunigiana → solo mail Lunigiana, (2) fallback su company quando Lunigiana fallisce, (3) forwarding disabilitato → mail company — sia per `store()` che per `v1store()`
+
+## Rischi
+
+- **SMTP sincrono**: `Mail::send()` è blocking — se lo SMTP Lunigiana è lento, i worker PHP-FPM possono esaurirsi sotto carico. Lasciato come follow-up documentato (richiederebbe refactor verso queue)
+- **Mailable mutabile**: la stessa istanza passata a più `send` consecutivi può ereditare stato interno dal send precedente. Mitigato documentando con commento che il Mailable non va riusato
+- **Fallback parziale nel fallback**: se la company ha più destinatari e uno fallisce nel fallback, la notifica è parzialmente consegnata — accettabile, comportamento pre-esistente
+- **Rollback**: il rollback del codice richiede di ripristinare il blocco `if ($company->ticket_email)` + `forwardToLunigiana` nei call site — procedura documentata in `notes.md`
+
+## Out of scope
+
+- Invio asincrono via queue (follow-up documentato)
+- Modifica alla logica di determinazione zona Lunigiana (`isLunigianaZone()`)
+- Modifica alla logica di derivazione `zone_id`
+- Generalizzazione della logica a company diverse da ERSU
+- Notifiche push o canali diversi dall'email
+
+## Moduli toccati
+
+- `app/Http/Controllers/TicketController.php` — nuovo metodo `sendTicketNotification()`; rimozione del doppio blocco email da `store()`, `v1store()`, `v1update()`; eventuale rimozione/deprecazione di `forwardToLunigiana()`
+- `tests/Feature/V2/TicketControllerTest.php` — nuovi test per i 3 scenari Lunigiana su `store()` e `v1store()`

--- a/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/plan.md
+++ b/docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/plan.md
@@ -1,0 +1,237 @@
+> Ticket: oc:8111
+
+# Piano — Modifica invio mail Lunigiana: esclusivo con fallback su mail company
+
+## Task 1 — Crea branch
+
+```bash
+git checkout -b feature/oc-8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback
+```
+
+---
+
+## Task 2 — Aggiungi `sendToCompany()` in `TicketController`
+
+Estrai il loop di invio alla company in un metodo privato dedicato, così può essere richiamato sia dal path normale sia dal fallback senza duplicare codice.
+
+**In `app/Http/Controllers/TicketController.php`**, aggiungi dopo `forwardToLunigiana`:
+
+```php
+private function sendToCompany(Company $company, \Illuminate\Mail\Mailable $mailable): void
+{
+    if ($company->ticket_email) {
+        foreach (explode(',', $company->ticket_email) as $recipient) {
+            Mail::to(trim($recipient))->send($mailable);
+        }
+    }
+}
+```
+
+---
+
+## Task 3 — Aggiungi `sendTicketNotification()` in `TicketController`
+
+Unico punto di routing email. Gestisce tutti i casi: forwarding disabilitato, zone_id mancante, zona non-Lunigiana, zona Lunigiana con fallback.
+
+**In `app/Http/Controllers/TicketController.php`**, aggiungi dopo `sendToCompany`:
+
+```php
+// NOTE: non riusare la stessa istanza $mailable tra invii multipli —
+// SymfonyMessage è mutabile e può portare stato residuo dal send precedente.
+private function sendTicketNotification(Ticket $ticket, Company $company, \Illuminate\Mail\Mailable $mailable): void
+{
+    if (!config('lunigiana.enabled')) {
+        Log::info('Lunigiana forwarding disabled, sending to company', ['ticket_id' => $ticket->id]);
+        $this->sendToCompany($company, $mailable);
+        return;
+    }
+
+    if (!$ticket->zone_id && $company->id === config('lunigiana.company_id')) {
+        Log::warning('ERSU ticket zone_id derivation failed, falling back to company email', ['ticket_id' => $ticket->id]);
+        $this->sendToCompany($company, $mailable);
+        return;
+    }
+
+    if (!$ticket->isLunigianaZone()) {
+        $this->sendToCompany($company, $mailable);
+        return;
+    }
+
+    $failed = false;
+    foreach (explode(',', config('lunigiana.email')) as $recipient) {
+        try {
+            Log::info('Sending Lunigiana email to ' . trim($recipient), ['ticket_id' => $ticket->id]);
+            Mail::to(trim($recipient))->send($mailable);
+        } catch (\Exception $e) {
+            $failed = true;
+            Log::error('Lunigiana forward failed', [
+                'ticket_id' => $ticket->id,
+                'recipient' => $recipient,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+
+    if ($failed) {
+        Log::warning('Lunigiana forward failed, falling back to company email', ['ticket_id' => $ticket->id]);
+        $this->sendToCompany($company, $mailable);
+    }
+}
+```
+
+---
+
+## Task 4 — Aggiorna `store()`: sostituisci doppio blocco con `sendTicketNotification`
+
+**In `app/Http/Controllers/TicketController.php`**, intorno alla riga 132, sostituisci:
+
+```php
+// Send a notification email to company for the newly created ticket
+if ($res) {
+    $company = Company::find($request->id);
+    if ($company->ticket_email) {
+        foreach (explode(',', $company->ticket_email) as $recipient) {
+            Mail::to($recipient)->send(new TicketCreated($ticket, $company));
+        }
+    }
+    // LUNIGIANA_FORWARD
+    $this->forwardToLunigiana($ticket, $company, new TicketCreated($ticket, $company));
+}
+```
+
+con:
+
+```php
+if ($res) {
+    $company = Company::find($request->id);
+    $this->sendTicketNotification($ticket, $company, new TicketCreated($ticket, $company));
+}
+```
+
+---
+
+## Task 5 — Aggiorna `v1store()`: sostituisci doppio blocco con `sendTicketNotification`
+
+**In `app/Http/Controllers/TicketController.php`**, intorno alla riga 227, sostituisci:
+
+```php
+// Send a notification email to company for the newly created ticket
+if ($res) {
+    $company = Company::find($request->id);
+    if ($company->ticket_email) {
+        foreach (explode(',', $company->ticket_email) as $recipient) {
+            Mail::to($recipient)->send(new TicketCreated($ticket, $company));
+        }
+    }
+    // LUNIGIANA_FORWARD
+    $this->forwardToLunigiana($ticket, $company, new TicketCreated($ticket, $company));
+}
+```
+
+con:
+
+```php
+if ($res) {
+    $company = Company::find($request->id);
+    $this->sendTicketNotification($ticket, $company, new TicketCreated($ticket, $company));
+}
+```
+
+---
+
+## Task 6 — Aggiorna `v1update()`: sostituisci doppio blocco con `sendTicketNotification`
+
+**In `app/Http/Controllers/TicketController.php`**, intorno alla riga 323, sostituisci:
+
+```php
+if($ticket->status == TicketStatus::Deleted){
+    $company = Company::find($ticket->company_id);
+    if ($company->ticket_email) {
+        foreach (explode(',', $company->ticket_email) as $recipient) {
+            Mail::to($recipient)->send(new TicketDeleted($ticket, $company));
+        }
+    }
+    // LUNIGIANA_FORWARD
+    $this->forwardToLunigiana($ticket, $company, new TicketDeleted($ticket, $company));
+}
+```
+
+con:
+
+```php
+if ($ticket->status == TicketStatus::Deleted) {
+    $company = Company::find($ticket->company_id);
+    $this->sendTicketNotification($ticket, $company, new TicketDeleted($ticket, $company));
+}
+```
+
+---
+
+## Task 7 — Rimuovi `forwardToLunigiana()`
+
+Il metodo è ora sostituito da `sendTicketNotification` + `sendToCompany`. Rimuovilo da `TicketController`.
+
+---
+
+## Task 8 — Aggiungi test in `TicketControllerTest`
+
+I test verificano il comportamento via layer HTTP (`Mail::fake()` + asserzioni sui destinatari). Aggiungere al fondo di `TicketControllerTest.php`.
+
+**Setup comune dei test Lunigiana** (helper nel test o in setUp):
+- Creare una company con `id` controllato e `ticket_email` valorizzato
+- Usare `Config::set('lunigiana.company_id', $company->id)` per allineare il config alla company di test
+- Creare una zona con `zone_id` in `config('lunigiana.zones')` oppure usare `Config::set('lunigiana.zones', [$zone->id])`
+- Assegnare il `zone_id` al ticket via il campo diretto (non via derivazione PostGIS)
+
+**Test 1 — Zona Lunigiana: solo mail Lunigiana, non company (`v1store`)**
+```
+Config::set('lunigiana.enabled', true)
+Config::set('lunigiana.company_id', $company->id)
+Config::set('lunigiana.email', 'lunigiana@test.it')
+Config::set('lunigiana.zones', [$zone->id])
+POST /api/v2/c/{company_id}/ticket con zone_id Lunigiana
+
+Mail::assertSent(TicketCreated::class, fn($m) => $m->hasTo('lunigiana@test.it'))
+Mail::assertNotSent(TicketCreated::class, fn($m) => $m->hasTo('test@example.com')) // company email
+```
+
+**Test 2 — Zona Lunigiana: fallback su company se Lunigiana fallisce (`v1store`)**
+
+Strategia: sovrascrivere il mailer di default con uno che lancia eccezione per l'indirizzo Lunigiana, usando `Mail::shouldSend()` (Laravel 11) oppure impostando un mailer `failmail` nel config di test che lancia sempre eccezione. In alternativa: usare `Event::listen(MessageSending::class, ...)` per intercettare e lanciare prima della consegna solo per l'indirizzo Lunigiana.
+```
+Config::set('lunigiana.enabled', true)
+// ... intercetta invio a lunigiana@test.it e lancia \Exception
+POST /api/v2/c/{company_id}/ticket con zone_id Lunigiana
+
+Mail::assertSent(TicketCreated::class, fn($m) => $m->hasTo('test@example.com')) // fallback company
+```
+
+**Test 3 — Forwarding disabilitato: mail a company (`v1store`)**
+```
+Config::set('lunigiana.enabled', false)
+POST /api/v2/c/{company_id}/ticket con zone_id Lunigiana
+
+Mail::assertSent(TicketCreated::class, fn($m) => $m->hasTo('test@example.com'))
+Mail::assertNotSent(TicketCreated::class, fn($m) => $m->hasTo('lunigiana@test.it'))
+```
+
+**Replica Test 1 e Test 3 per `store()`** (endpoint non-v1, stesso comportamento atteso).
+
+---
+
+## Task 9 — Verifica test suite
+
+```bash
+docker exec php_portapporta php artisan config:clear
+docker exec php_portapporta php artisan test --filter=TicketControllerTest
+```
+
+Tutti i test devono passare (nuovi e preesistenti).
+
+---
+
+## Commit
+
+```
+feat(oc:8111): invio mail Lunigiana esclusivo con fallback su company
+```

--- a/tests/Feature/V2/TicketControllerTest.php
+++ b/tests/Feature/V2/TicketControllerTest.php
@@ -447,6 +447,120 @@ class TicketControllerTest extends TestCase
         Carbon::setTestNow();
     }
 
+    // --- Lunigiana email routing tests ---
+
+    private function setupLunigianaConfig(int $companyId, int $zoneId, string $lunigianaEmail = 'lunigiana@test.it'): void
+    {
+        config([
+            'lunigiana.enabled'    => true,
+            'lunigiana.company_id' => $companyId,
+            'lunigiana.zones'      => [$zoneId],
+            'lunigiana.email'      => $lunigianaEmail,
+        ]);
+    }
+
+    /** @test */
+    public function testV1StoreLunigianaZoneSendsOnlyToLunigiana(): void
+    {
+        $zone = $this->createZone($this->company);
+        $this->setupLunigianaConfig($this->company->id, $zone->id);
+
+        Sanctum::actingAs($this->user);
+        Mail::fake();
+
+        $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'zone_id'     => $zone->id,
+        ]);
+
+        Mail::assertSent(TicketCreated::class, fn ($m) => $m->hasTo('lunigiana@test.it'));
+        Mail::assertNotSent(TicketCreated::class, fn ($m) => $m->hasTo('test@example.com'));
+    }
+
+    /** @test */
+    public function testV1StoreLunigianaFailureFallsBackToCompany(): void
+    {
+        $zone = $this->createZone($this->company);
+        $this->setupLunigianaConfig($this->company->id, $zone->id);
+
+        Sanctum::actingAs($this->user);
+        Mail::fake();
+
+        $this->instance(
+            \App\Http\Controllers\TicketController::class,
+            \Mockery::mock(\App\Http\Controllers\TicketController::class)
+                ->makePartial()
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('sendLunigianaEmails')
+                ->andThrow(new \Exception('SMTP error'))
+                ->getMock()
+        );
+
+        $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'zone_id'     => $zone->id,
+        ]);
+
+        Mail::assertSent(TicketCreated::class, fn ($m) => $m->hasTo('test@example.com'));
+        Mail::assertNotSent(TicketCreated::class, fn ($m) => $m->hasTo('lunigiana@test.it'));
+    }
+
+    /** @test */
+    public function testV1StoreLunigianaDisabledSendsToCompany(): void
+    {
+        $zone = $this->createZone($this->company);
+        $this->setupLunigianaConfig($this->company->id, $zone->id);
+        config(['lunigiana.enabled' => false]);
+
+        Sanctum::actingAs($this->user);
+        Mail::fake();
+
+        $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'zone_id'     => $zone->id,
+        ]);
+
+        Mail::assertSent(TicketCreated::class, fn ($m) => $m->hasTo('test@example.com'));
+        Mail::assertNotSent(TicketCreated::class, fn ($m) => $m->hasTo('lunigiana@test.it'));
+    }
+
+    /** @test */
+    public function testStoreLunigianaZoneSendsOnlyToLunigiana(): void
+    {
+        $zone = $this->createZone($this->company);
+        $this->setupLunigianaConfig($this->company->id, $zone->id);
+
+        Sanctum::actingAs($this->user);
+        Mail::fake();
+
+        $this->post('/api/c/' . "{$this->company->id}/ticket", [
+            'ticket_type' => 'info',
+            'zone_id'     => $zone->id,
+        ]);
+
+        Mail::assertSent(TicketCreated::class, fn ($m) => $m->hasTo('lunigiana@test.it'));
+        Mail::assertNotSent(TicketCreated::class, fn ($m) => $m->hasTo('test@example.com'));
+    }
+
+    /** @test */
+    public function testStoreLunigianaDisabledSendsToCompany(): void
+    {
+        $zone = $this->createZone($this->company);
+        $this->setupLunigianaConfig($this->company->id, $zone->id);
+        config(['lunigiana.enabled' => false]);
+
+        Sanctum::actingAs($this->user);
+        Mail::fake();
+
+        $this->post('/api/c/' . "{$this->company->id}/ticket", [
+            'ticket_type' => 'info',
+            'zone_id'     => $zone->id,
+        ]);
+
+        Mail::assertSent(TicketCreated::class, fn ($m) => $m->hasTo('test@example.com'));
+        Mail::assertNotSent(TicketCreated::class, fn ($m) => $m->hasTo('lunigiana@test.it'));
+    }
+
     private function createCalendarWithStopTime(\App\Models\Zone $zone, string $stopTime): void
     {
         $userType = $this->createUserType();


### PR DESCRIPTION
## Summary

- Sostituisce il doppio invio (company + Lunigiana) con routing esclusivo: per le zone Lunigiana la mail va **solo** a Lunigiana
- Se anche un solo destinatario Lunigiana fallisce → log `error` + fallback sulla mail company
- Quando `LUNIGIANA_FORWARD_ENABLED=false` → mail a company (graceful degradation, invariato)
- Logica centralizzata in `sendTicketNotification()` — rimosso `forwardToLunigiana()`
- Stessa logica per `TicketCreated` (`store`, `v1store`) e `TicketDeleted` (`v1update`)
- 5 nuovi test PHPUnit per i 3 scenari Lunigiana su `store()` e `v1store()`

## Test plan

- [ ] Verificare in Mailpit che un ticket in zona Lunigiana invii solo a `urp@lunigianaambiente.it` (non alla company)
- [ ] Verificare che con `LUNIGIANA_FORWARD_ENABLED=false` la mail vada alla company
- [ ] Suite test: `docker exec php_portapporta php artisan test --filter=TicketControllerTest` (23/23 pass)

## Note

Docs: `docs/features/8111-modifica-invio-mail-lunigiana-esclusivo-con-fallback/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)