### PR TITLE
fix(oc:8113): ricalcolo coordinate/zona se discrepanza con indirizzo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,6 @@ PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+# Disabilita il controllo di discrepanza coordinate/indirizzo (patch temporanea, rimuovere con fix app)
+ADDRESS_DISCREPANCY_CHECK_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 | Invio mail Lunigiana esclusivo con fallback su company | oc:8111 | `app/Http/Controllers/TicketController.php` | Routing esclusivo: zone Lunigiana → solo urp@lunigianaambiente.it; fallback su company in caso di errore SMTP; `LUNIGIANA_FORWARD_ENABLED=false` → company (graceful degradation) |
 | Smistamento automatico segnalazioni Lunigiana | oc:7616 | `config/lunigiana.php`, `app/Models/Ticket.php`, `app/Http/Controllers/TicketController.php` | Routing email ticket verso urp@lunigianaambiente.it per le zone Lunigiana di ERSU (aggiornato da oc:8111) |
 | Bug oc:7609 — bloccanti 3 e 4 backend | oc:8054 | `app/Http/Controllers/CalendarController.php`, `app/Http/Controllers/TicketController.php`, `app/Nova/Ticket.php`, `resources/views/emails/tickets/created.blade.php` | Validazione server-side `missed_withdraw_date`, log warning per `stop_time` malformato, `city` in `location_address` per ticket senza FK zona |
+| Ricalcolo coordinate/zona se discrepanza con indirizzo | oc:8113 | `app/Http/Controllers/TicketController.php`, `config/app.php` | Forward geocoding Nominatim in `v1store`/`v1update`; se zona testo ≠ zona coordinate → sovrascrive geometry e zone_id; fail-open; kill switch `ADDRESS_DISCREPANCY_CHECK_ENABLED` |
 
 ## Decisioni architetturali
 
@@ -104,6 +105,18 @@ Un guard in `TestCase::setUp()` abortisce con messaggio esplicito se i test veng
 - `forwardToLunigiana()` rimosso in oc:8111, sostituito da `sendTicketNotification()`
 - Lista `zone_id` Lunigiana configurabile in `config/lunigiana.php`, disabilitabile via `LUNIGIANA_FORWARD_ENABLED=false`
 - Dipende dalla migrazione `oc_7612` (`add_zone_id_to_tickets_table`) in produzione
+
+### Ricalcolo coordinate/zona se discrepanza con indirizzo (oc:8113)
+- `_correctLocationFromAddress(Ticket, Request): void` — metodo privato chiamato pre-save in `v1store` e `v1update`, dopo l'assegnazione di `geometry` e prima di `_deriveZoneId()`. Non tocca `store()` (non-v1) perché lì l'indirizzo è costruito da reverse geocoding, non editabile.
+- Guard conditions: kill switch disabilitato → return; `address_id` non null → return; `city` assente → return; `geometry` null → return. Fail-open su qualsiasi condizione non soddisfatta.
+- Forward geocoding con campi strutturati Nominatim (`street`, `city`) — mai concatenazione con em-dash che invaliderebbe la query.
+- Confronto via `Zone::findByPoint` (riutilizza oc:8099): zone stessa → nessuna correzione; zone diverse → sovrascrive `$ticket->geometry` e `$ticket->zone_id` pre-save (un solo write al DB).
+- `ticket_id` è null nei `Log::` di `v1store` (il save non è ancora avvenuto) — comportamento atteso, non un bug.
+- Nominatim rate limiting (1 req/sec, no API key): un 429 o risposta vuota viene trattato come fail-open silenzioso — `curlRequest` non controlla il codice HTTP.
+- Kill switch: `ADDRESS_DISCREPANCY_CHECK_ENABLED=true` in `.env`; `config('app.address_discrepancy_check_enabled', true)` in `config/app.php`.
+- `Http` facade (Guzzle) invece di `curlRequest()` — `CurlServiceProvider` usa `User-Agent: PostmanRuntime/7.29.2` che Nominatim blocca esplicitamente. `Http::withHeaders(['User-Agent' => 'portapporta (+https://portapporta.webmapp.it)'])` non è bloccato e rispetta la usage policy.
+- `ConnectionException` catchata esplicitamente nel try-catch attorno a `Http::get()` — Guzzle lancia su network failure (a differenza di `curlRequest()` che catturava internamente), senza il catch il fail-open sarebbe diventato un 500.
+- TODO nel codice: rimuovere quando il fix frontend sarà live e tutti gli utenti avranno aggiornato.
 
 ### Bug oc:7609 bloccanti 3-4 (oc:8054)
 - `CalendarController::isCollectionInProgress(int $zoneId): bool` — metodo **public** chiamato da `TicketController` via `app(CalendarController::class)`. Non static per evitare refactor invasivo. Logger inizializzato con `??` per coprire l'invocazione fuori dal ciclo normale.

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Validation\Rule;
 
@@ -212,6 +213,7 @@ class TicketController extends Controller
             $location_address .= $request->city;
         }
         $ticket->location_address = $location_address;
+        $this->_correctLocationFromAddress($ticket, $request);
         if (is_null($ticket->zone_id)) {
             $ticket->zone_id = $this->_deriveZoneId($ticket);
         }
@@ -298,6 +300,7 @@ class TicketController extends Controller
             $location_address .= $request->city;
         }
         $ticket->location_address = $location_address;
+        $this->_correctLocationFromAddress($ticket, $request);
         if (is_null($ticket->zone_id)) {
             $ticket->zone_id = $this->_deriveZoneId($ticket);
         }
@@ -376,6 +379,93 @@ class TicketController extends Controller
                 Mail::to(trim($recipient))->send($mailable);
             }
         }
+    }
+
+    // TODO: rimuovere questo metodo una volta che l'app avrà il fix lato frontend
+    // e tutti gli utenti avranno aggiornato. Disabilitabile via ADDRESS_DISCREPANCY_CHECK_ENABLED=false.
+    private function _correctLocationFromAddress(Ticket $ticket, Request $request): void
+    {
+        if (!config('app.address_discrepancy_check_enabled', true)) {
+            return;
+        }
+
+        if ($ticket->address_id) {
+            return;
+        }
+
+        if (empty($request->city)) {
+            return;
+        }
+
+        if (!$ticket->geometry) {
+            return;
+        }
+
+        $street = trim(($request->address ?? '') . ' ' . ($request->house_number ?? ''));
+        try {
+            $httpResponse = Http::withHeaders(['User-Agent' => 'portapporta (+https://portapporta.webmapp.it)'])
+                ->get('https://nominatim.openstreetmap.org/search', [
+                    'street'       => $street,
+                    'city'         => $request->city,
+                    'format'       => 'json',
+                    'limit'        => 1,
+                    'countrycodes' => 'it',
+                ]);
+        } catch (\Illuminate\Http\Client\ConnectionException $e) {
+            Log::info('Address discrepancy check: Nominatim unreachable, keeping original coordinates', [
+                'ticket_id' => $ticket->id,
+                'address'   => $street . ' — ' . $request->city,
+            ]);
+            return;
+        }
+
+        if (!$httpResponse->successful()) {
+            Log::info('Address discrepancy check: Nominatim request failed, keeping original coordinates', [
+                'ticket_id' => $ticket->id,
+                'status'    => $httpResponse->status(),
+                'address'   => $street . ' — ' . $request->city,
+            ]);
+            return;
+        }
+
+        $response = $httpResponse->json();
+
+        if (empty($response) || !isset($response[0]['lat'], $response[0]['lon'])) {
+            Log::info('Address discrepancy check: Nominatim returned no results, keeping original coordinates', [
+                'ticket_id' => $ticket->id,
+                'address'   => $street . ' — ' . $request->city,
+            ]);
+            return;
+        }
+
+        $textLat = (float) $response[0]['lat'];
+        $textLon = (float) $response[0]['lon'];
+
+        $textGeometry = (DB::select(
+            DB::raw("SELECT ST_GeomFromText('POINT($textLon $textLat)') as g;")
+        ))[0]->g;
+
+        $zoneFromText   = Zone::findByPoint($textGeometry, $ticket->company_id);
+        $zoneFromCoords = Zone::findByPoint($ticket->geometry, $ticket->company_id);
+
+        if (!$zoneFromText || ($zoneFromCoords && $zoneFromCoords->id === $zoneFromText->id)) {
+            return;
+        }
+
+        $originalCoords = $this->_geometryToLatLon($ticket->geometry);
+        Log::warning('Address discrepancy detected: overriding coordinates and zone from text address', [
+            'ticket_id'         => $ticket->id,
+            'original_zone_id'  => $zoneFromCoords?->id,
+            'original_lat'      => $originalCoords[0] ?? null,
+            'original_lon'      => $originalCoords[1] ?? null,
+            'corrected_zone_id' => $zoneFromText->id,
+            'corrected_lat'     => $textLat,
+            'corrected_lon'     => $textLon,
+            'address'           => $street . ' — ' . $request->city,
+        ]);
+
+        $ticket->geometry = $textGeometry;
+        $ticket->zone_id  = $zoneFromText->id;
     }
 
     private function _deriveZoneId(Ticket $ticket): ?int

--- a/config/app.php
+++ b/config/app.php
@@ -212,4 +212,6 @@ return [
         'Agent' => Jenssegers\Agent\Facades\Agent::class,
     ])->toArray(),
 
+    'address_discrepancy_check_enabled' => env('ADDRESS_DISCREPANCY_CHECK_ENABLED', true),
+
 ];

--- a/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/notes.md
+++ b/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/notes.md
@@ -1,0 +1,42 @@
+> Ticket: oc:8113
+
+# Note implementative — Ricalcolo automatico coordinate/zona se discrepanza con indirizzo
+
+## Fix emersi dalla review
+
+### User-Agent bloccato da Nominatim (`PostmanRuntime/7.29.2`)
+Il `CurlServiceProvider` invia `User-Agent: PostmanRuntime/7.29.2`. Nominatim blocca esplicitamente questo agent (risponde "Access denied" in HTML → `json_decode` → `null` → fail-open silenzioso). Tutte le chiamate reali dal server fallivano.
+
+Soluzione: sostituire `curlRequest()` in `_correctLocationFromAddress()` con l'`Http` facade di Laravel (Guzzle), che permette di impostare un User-Agent conforme alla Nominatim usage policy: `portapporta (+https://portapporta.webmapp.it)`. `CurlServiceProvider` non è stato modificato (continuava in `store()` e altrove senza problemi).
+
+### ConnectionException non gestita (fail-open rotto)
+La vecchia `curlRequest()` aveva un try-catch interno che catturava qualsiasi eccezione e restituiva `null`. Passando a `Http::get()`, se Nominatim è irraggiungibile Guzzle lancia `ConnectionException` non gestita → 500 per l'app → ticket non creato. Corretto con un try-catch esplicito attorno alla chiamata Http.
+
+Aggiunto anche il test `testNominatimUnreachableIsFailOpen` che verifica il comportamento.
+
+## Deviazioni dal piano
+
+### Log context ampliato rispetto a plan.md
+
+Il `Log::warning` nel piano originale includeva `original_zone_id`, `corrected_zone_id`, `corrected_lat`, `corrected_lon`, `address`. In implementazione sono stati aggiunti:
+- `ticket_id` — identificativo ticket (null pre-save, valorizzato in v1update)
+- `original_lat`, `original_lon` — coordinate originali decodificate via `_geometryToLatLon()` per facilità di debug
+
+Stessa aggiunta per `Log::info` (Nominatim senza risultati): aggiunto `ticket_id`.
+
+### `ticket_id` è null nei log di `v1store`
+
+`_correctLocationFromAddress()` viene chiamato prima di `$ticket->save()`, quindi `$ticket->id` è null durante la creazione. In `v1update` il ticket è già persistito e `ticket_id` è valorizzato. Comportamento atteso, non un bug.
+
+## Diagnosi test manuale ticket #1238
+
+Il ticket #1238 (address: "Via Fratelli Rosselli, 25 — Seravezza", zone_id=95 Pietrasanta) ha triggherato il check ma il fail-open ha mantenuto le coordinate originali. Il log mostra:
+
+```
+local.INFO: Address discrepancy check: Nominatim returned no results, keeping original coordinates
+  {"ticket_id":null,"address":"Via Fratelli Rosselli 25 — Seravezza"}
+```
+
+Causa: Nominatim ha risposto con array vuoto `[]` per quella specifica richiesta (probabilmente rate limiting — erano stati effettuati 2 check nei 10 minuti precedenti). Il comportamento fail-open è corretto.
+
+Verifica post-hoc: la stessa query Nominatim restituisce ora `lat=43.9740197, lon=10.2006714` (zona 91 - Seravezza "Piana e centro"), confermando che le coordinate sarebbero state corrette se Nominatim non avesse avuto il momentaneo problema.

--- a/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/overview.md
+++ b/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/overview.md
@@ -1,0 +1,44 @@
+> Ticket: oc:8113
+
+# Ricalcolo automatico coordinate/zona se discrepanza con indirizzo
+
+## Cosa cambia
+
+Quando il backend riceve un ticket da `v1store` o `v1update` senza `address_id` (flusso custom da mappa), controlla se le coordinate ricevute e il testo dell'indirizzo scritto dall'utente appartengono alla stessa zona. Se appartengono a zone diverse, sovrascrive le coordinate (geometry) e la zona (zone_id) con quelle derivate dal forward geocoding del testo indirizzo.
+
+## Perché
+
+L'app consente all'utente di selezionare un punto sulla mappa (che georeferenzia automaticamente le coordinate e pre-compila l'indirizzo), ma poi permette di modificare il testo dell'indirizzo a mano. Se l'utente cambia l'indirizzo testo dopo aver cliccato sulla mappa, le coordinate restano quelle del click originale mentre il testo riflette una posizione diversa. Il risultato è un ticket inviato agli operatori ERSU con zona e comune errati (come nel caso segnalazione #51467: coordinate Pietrasanta, indirizzo Fosdinovo).
+
+## Requisiti
+
+- [ ] Il controllo è abilitato tramite variabile d'ambiente `ADDRESS_DISCREPANCY_CHECK_ENABLED` (default `true`); se `false` il ticket viene accettato senza controllo (kill switch, analogo a `LUNIGIANA_FORWARD_ENABLED`)
+- [ ] Il controllo si attiva solo in `v1store` e `v1update`, non in `store()`
+- [ ] Il controllo si attiva solo quando `$ticket->address_id` è null (valore sul modello Eloquent idratato dal DB, non presenza nel payload — gestisce correttamente le patch parziali di `v1update`)
+- [ ] La query Nominatim usa i campi strutturati: `street={address}+{house_number}&city={city}&format=json&limit=1&countrycodes=it` — nessuna concatenazione con separatori em-dash
+- [ ] Se `city` è assente nel payload, il controllo viene saltato (query troppo vaga)
+- [ ] Si ricava la zona per le coordinate forward geocodificate (`Zone::findByPoint`)
+- [ ] Si ricava la zona per le coordinate ricevute dall'app (`Zone::findByPoint`)
+- [ ] Se le due zone differiscono e il forward geocoding ha avuto successo, geometry e zone_id vengono sostituiti con i valori derivati dal testo
+- [ ] In caso di fallimento del geocoding (Nominatim irraggiungibile, senza risultati, o `city` assente): fail-open, il ticket viene accettato con le coordinate originali
+- [ ] La correzione viene loggata con `Log::warning` includendo coordinate originali, coordinate corrette e zone coinvolte
+- [ ] Il codice include un `// TODO:` esplicito che indica che il controllo potrà essere rimosso una volta che l'app avrà il fix lato frontend e tutti gli utenti avranno aggiornato
+- [ ] La correzione avviene pre-save (prima del `save()` e prima dell'invio email), seguendo la convenzione di oc:8099
+
+## Rischi
+
+- **Nominatim può restituire risultati ambigui o plausibili ma errati** per indirizzi omonimi (es. "Via Roma" presente in più comuni). Mitigazione: fail-open — se le zone coincidono la correzione non scatta; se scatta con dati sbagliati il `Log::warning` è l'unico segnale.
+- **Latenza aggiuntiva sincrona + timeout infinito**: `CurlServiceProvider` ha `CURLOPT_TIMEOUT => 0`. Se Nominatim non risponde, il worker PHP-FPM si blocca. Accettato come compromesso temporaneo — follow-up per rendere il check asincrono una volta che il fix frontend è live e il kill switch può essere disattivato.
+- **Nominatim rate limiting (1 req/sec)**: il progetto non usa un'istanza self-hosted né una chiave API. Sotto carico potrebbe essere throttolato (HTTP 429). `curlRequest` non controlla il codice HTTP di risposta, quindi un 429 viene trattato come fail-open silenzioso.
+- **False positive su click mappa senza modifica testo**: il controllo gira anche quando coordinate e testo sono consistenti (nessuna modifica utente). Overhead di una chiamata Nominatim inutile — nessun danno funzionale grazie al fail-open.
+
+## Out of scope
+
+- Fix lato app (frontend) — rimandato a un ciclo successivo
+- Rendering asincrono della correzione (queue job) — rimandato a follow-up
+- Applicazione a `store()` (non-v1) — non affetto: quel metodo costruisce `location_address` da reverse geocoding delle coordinate, senza testo editabile
+- Applicazione quando `address_id` è valorizzato — la zona è già corretta per costruzione dall'indirizzo salvato
+
+## Moduli toccati
+
+- `app/Http/Controllers/TicketController.php` — aggiunta logica di discrepancy check + forward geocoding in `v1store` e `v1update`

--- a/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/plan.md
+++ b/docs/features/8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo/plan.md
@@ -1,0 +1,214 @@
+> Ticket: oc:8113
+
+# Piano implementativo — Ricalcolo automatico coordinate/zona se discrepanza con indirizzo
+
+## Task 1 — Kill switch in config/app.php
+
+**File:** `config/app.php`
+
+Aggiungere in fondo all'array di configurazione:
+
+```php
+'address_discrepancy_check_enabled' => env('ADDRESS_DISCREPANCY_CHECK_ENABLED', true),
+```
+
+Aggiungere al `.env` (e `.env.example` se presente):
+
+```
+ADDRESS_DISCREPANCY_CHECK_ENABLED=true
+```
+
+---
+
+## Task 2 — Metodo privato `_correctLocationFromAddress()`
+
+**File:** `app/Http/Controllers/TicketController.php`
+
+Aggiungere un metodo privato dopo `_deriveZoneId()`:
+
+```php
+private function _correctLocationFromAddress(Ticket $ticket, Request $request): void
+{
+    // TODO: rimuovere questo controllo una volta che l'app avrà il fix lato frontend
+    // e tutti gli utenti avranno aggiornato. Disabilitabile via ADDRESS_DISCREPANCY_CHECK_ENABLED=false.
+    if (!config('app.address_discrepancy_check_enabled', true)) {
+        return;
+    }
+
+    // Solo per flusso da mappa (nessun indirizzo salvato)
+    if ($ticket->address_id) {
+        return;
+    }
+
+    // city obbligatoria per una query Nominatim significativa
+    if (empty($request->city)) {
+        return;
+    }
+
+    // Coordinate originali necessarie per il confronto
+    if (!$ticket->geometry) {
+        return;
+    }
+
+    // Forward geocoding del testo indirizzo via Nominatim
+    $street = trim(($request->address ?? '') . ' ' . ($request->house_number ?? ''));
+    $query = http_build_query([
+        'street'       => $street,
+        'city'         => $request->city,
+        'format'       => 'json',
+        'limit'        => 1,
+        'countrycodes' => 'it',
+    ]);
+    $url = 'https://nominatim.openstreetmap.org/search?' . $query;
+    $response = $this->curlRequest($url);
+
+    if (empty($response) || !isset($response[0]['lat'], $response[0]['lon'])) {
+        Log::info('Address discrepancy check: Nominatim returned no results, keeping original coordinates', [
+            'ticket_city'    => $request->city,
+            'ticket_address' => $street,
+        ]);
+        return;
+    }
+
+    $textLat = (float) $response[0]['lat'];
+    $textLon = (float) $response[0]['lon'];
+
+    // Geometria dalle coordinate testuali
+    $textGeometry = (DB::select(
+        DB::raw("SELECT ST_GeomFromText('POINT($textLon $textLat)') as g;")
+    ))[0]->g;
+
+    // Zona dal testo vs zona dalle coordinate originali
+    $zoneFromText   = Zone::findByPoint($textGeometry, $ticket->company_id);
+    $zoneFromCoords = Zone::findByPoint($ticket->geometry, $ticket->company_id);
+
+    // Nessuna discrepanza o zona testo non trovata: nessuna correzione
+    if (!$zoneFromText || ($zoneFromCoords && $zoneFromCoords->id === $zoneFromText->id)) {
+        return;
+    }
+
+    Log::warning('Address discrepancy detected: overriding coordinates and zone from text address', [
+        'original_zone_id'  => $zoneFromCoords?->id,
+        'corrected_zone_id' => $zoneFromText->id,
+        'corrected_lat'     => $textLat,
+        'corrected_lon'     => $textLon,
+        'address'           => $street . ' — ' . $request->city,
+    ]);
+
+    $ticket->geometry = $textGeometry;
+    $ticket->zone_id  = $zoneFromText->id;
+}
+```
+
+---
+
+## Task 3 — Chiamata in `v1store`
+
+**File:** `app/Http/Controllers/TicketController.php`, metodo `v1store`
+
+Inserire la chiamata a `_correctLocationFromAddress()` **dopo** l'assegnazione di `geometry` e **prima** di `_deriveZoneId()`.
+
+Il codice attuale (righe ~195-217):
+
+```php
+if ($request->exists('location')) {
+    $ticket->geometry = (DB::select(DB::raw("SELECT ST_GeomFromText('POINT({$request->location[0]} {$request->location[1]})') as g;")))[0]->g;
+}
+// ... costruzione location_address ...
+$ticket->location_address = $location_address;
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+Diventa:
+
+```php
+if ($request->exists('location')) {
+    $ticket->geometry = (DB::select(DB::raw("SELECT ST_GeomFromText('POINT({$request->location[0]} {$request->location[1]})') as g;")))[0]->g;
+}
+// ... costruzione location_address ...
+$ticket->location_address = $location_address;
+$this->_correctLocationFromAddress($ticket, $request);
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+**Nota:** `_correctLocationFromAddress()` può impostare `$ticket->zone_id` direttamente; in quel caso `_deriveZoneId()` viene saltato perché `zone_id` non è più null.
+
+---
+
+## Task 4 — Chiamata in `v1update`
+
+**File:** `app/Http/Controllers/TicketController.php`, metodo `v1update`
+
+Stessa posizione: dopo geometry, prima di `_deriveZoneId()`. In `v1update` il ticket è già persistito (ha zone_id dal DB), ma la correzione deve poter sovrascrivere anche un zone_id esistente. Il metodo lo gestisce assegnando direttamente `$ticket->zone_id`.
+
+Il codice attuale (righe ~280-303):
+
+```php
+if ($request->exists('location')) {
+    $ticket->geometry = (DB::select(DB::raw("SELECT ST_GeomFromText('POINT({$request->location[0]} {$request->location[1]})') as g;")))[0]->g;
+}
+// ... costruzione location_address ...
+$ticket->location_address = $location_address;
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+Diventa:
+
+```php
+if ($request->exists('location')) {
+    $ticket->geometry = (DB::select(DB::raw("SELECT ST_GeomFromText('POINT({$request->location[0]} {$request->location[1]})') as g;")))[0]->g;
+}
+// ... costruzione location_address ...
+$ticket->location_address = $location_address;
+$this->_correctLocationFromAddress($ticket, $request);
+if (is_null($ticket->zone_id)) {
+    $ticket->zone_id = $this->_deriveZoneId($ticket);
+}
+```
+
+---
+
+## Task 5 — Test
+
+**File:** `tests/Feature/TicketControllerDiscrepancyTest.php` (nuovo file)
+
+Scenari da coprire con `RefreshDatabase` su `pap_test`:
+
+| Scenario | Comportamento atteso |
+|---|---|
+| `address_id` presente → | nessuna correzione, coordinate originali mantenute |
+| `city` assente → | nessuna correzione, fail-open |
+| Nominatim senza risultati (mock `CurlServiceProvider`) → | fail-open, coordinate originali |
+| Zone coincidono → | nessuna correzione |
+| Zone differiscono → | geometry e zone_id sovrascritti con quelli del testo |
+| Kill switch `ADDRESS_DISCREPANCY_CHECK_ENABLED=false` → | nessuna correzione |
+
+**Mocking di CurlServiceProvider** nei test:
+```php
+$this->mock(\App\Providers\CurlServiceProvider::class, function ($mock) {
+    $mock->shouldReceive('exec')
+         ->andReturn(json_encode([['lat' => '44.1234', 'lon' => '9.8765']]));
+});
+```
+
+---
+
+## Sequenza di esecuzione
+
+1. Task 1 — config/app.php + .env
+2. Task 2 — metodo `_correctLocationFromAddress()`
+3. Task 3 — chiamata in v1store
+4. Task 4 — chiamata in v1update
+5. Task 5 — test
+
+**Commit:** `fix(oc:8113): ricalcolo coordinate/zona se discrepanza con indirizzo`
+
+**Branch:** `feature/oc-8113-ricalcolo-automatico-coordinate-zona-discrepanza-indirizzo`
+
+**PR verso:** `develop`

--- a/tests/Feature/V2/TicketDiscrepancyCheckTest.php
+++ b/tests/Feature/V2/TicketDiscrepancyCheckTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Feature\V2;
+
+use App\Models\Company;
+use App\Models\Address;
+use App\Models\Ticket;
+use App\Models\Zone;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+use Tests\Feature\V2\FeatureTestV2UtilsFunctions;
+
+class TicketDiscrepancyCheckTest extends TestCase
+{
+    use DatabaseTransactions, FeatureTestV2UtilsFunctions;
+
+    private Company $company;
+    private Zone $zoneA;
+    private Zone $zoneB;
+
+    const API_PREFIX_COMPANY = '/api/v2/c/';
+    const API_PREFIX_TICKET  = '/api/v2/ticket/';
+
+    // Zone A: lon 10.0-10.5, lat 43.5-44.0 (simula area Pietrasanta)
+    const ZONE_A_POLYGON = [[10.0, 43.5], [10.5, 43.5], [10.5, 44.0], [10.0, 44.0], [10.0, 43.5]];
+    const POINT_IN_A = ['lon' => 10.24, 'lat' => 43.96];
+
+    // Zone B: lon 9.6-10.0, lat 44.0-44.5 (simula area Fosdinovo)
+    const ZONE_B_POLYGON = [[9.6, 44.0], [10.0, 44.0], [10.0, 44.5], [9.6, 44.5], [9.6, 44.0]];
+    const POINT_IN_B = ['lon' => 9.89, 'lat' => 44.13];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+        $this->company = $this->createCompany();
+        $this->zoneA   = $this->makeZoneWithPolygon(self::ZONE_A_POLYGON, $this->company);
+        $this->zoneB   = $this->makeZoneWithPolygon(self::ZONE_B_POLYGON, $this->company);
+    }
+
+    private function makeZoneWithPolygon(array $coords, Company $company): Zone
+    {
+        $wkt      = 'MULTIPOLYGON(((' . implode(', ', array_map(fn($p) => "{$p[0]} {$p[1]}", $coords)) . ')))';
+        $geometry = DB::selectOne('SELECT ST_GeomFromText(?, 4326) AS g', [$wkt])->g;
+
+        return Zone::create([
+            'company_id' => $company->id,
+            'comune'     => 'Test',
+            'label'      => 'Test Zone',
+            'url'        => 'http://test.example',
+            'geometry'   => $geometry,
+        ]);
+    }
+
+    private function mockNominatimWithPoint(float $lat, float $lon): void
+    {
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => Http::response(
+                [['lat' => (string) $lat, 'lon' => (string) $lon]],
+                200
+            ),
+        ]);
+    }
+
+    private function mockNominatimEmpty(): void
+    {
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => Http::response([], 200),
+        ]);
+    }
+
+    /** @test */
+    public function testDiscrepancyDetectedOverridesZoneAndGeometry(): void
+    {
+        // Nominatim geocodifica il testo → punto in zona B
+        $this->mockNominatimWithPoint(self::POINT_IN_B['lat'], self::POINT_IN_B['lon']);
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        // location → zona A, testo → zona B
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Giovanni XXIII',
+            'house_number' => '9',
+            'city'        => 'Fosdinovo',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        $ticketId = $response->json('data.id');
+
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneB->id,
+        ]);
+
+        $this->assertDatabaseMissing('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneA->id,
+        ]);
+    }
+
+    /** @test */
+    public function testNoDiscrepancyKeepsOriginalZone(): void
+    {
+        // Nominatim geocodifica il testo → punto ancora in zona A
+        $this->mockNominatimWithPoint(self::POINT_IN_A['lat'], self::POINT_IN_A['lon']);
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Roma',
+            'house_number' => '1',
+            'city'        => 'Pietrasanta',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        $ticketId = $response->json('data.id');
+
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneA->id,
+        ]);
+    }
+
+    /** @test */
+    public function testNominatimNoResultsIsFailOpen(): void
+    {
+        $this->mockNominatimEmpty();
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Inesistente',
+            'city'        => 'ComuneNonEsiste',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        $ticketId = $response->json('data.id');
+
+        // fail-open: zona derivata dalle coordinate originali (zona A)
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneA->id,
+        ]);
+    }
+
+    /** @test */
+    public function testNominatimUnreachableIsFailOpen(): void
+    {
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => function () {
+                throw new \Illuminate\Http\Client\ConnectionException('Nominatim unreachable');
+            },
+        ]);
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Giovanni XXIII',
+            'city'        => 'Fosdinovo',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        $ticketId = $response->json('data.id');
+        // fail-open: ticket creato con le coordinate originali (zona A)
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneA->id,
+        ]);
+    }
+
+    /** @test */
+    public function testAddressIdPresentSkipsCheck(): void
+    {
+        // Nominatim non deve essere chiamato
+        Http::fake();
+
+        $user    = $this->createUser();
+        $address = $this->createAddress($user, $this->zoneB);
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address_id'  => $address->id,
+            'address'     => 'Via Test',
+            'city'        => 'Fosdinovo',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function testMissingCitySkipsCheck(): void
+    {
+        // Senza city la query Nominatim sarebbe troppo vaga: il check non parte
+        Http::fake();
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Roma',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        Http::assertNothingSent();
+    }
+
+    /** @test */
+    public function testKillSwitchDisabledSkipsCheck(): void
+    {
+        config(['app.address_discrepancy_check_enabled' => false]);
+
+        Http::fake();
+
+        $user = $this->createUser();
+        Sanctum::actingAs($user);
+
+        $response = $this->post(self::API_PREFIX_COMPANY . "{$this->company->id}/ticket", [
+            'ticket_type' => 'reservation',
+            'address'     => 'Via Giovanni XXIII',
+            'city'        => 'Fosdinovo',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $response->assertStatus(200);
+        Http::assertNothingSent();
+        // zona non corretta: rimane quella delle coordinate originali (A)
+        $ticketId = $response->json('data.id');
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticketId,
+            'zone_id' => $this->zoneA->id,
+        ]);
+    }
+
+    /** @test */
+    public function testV1UpdateDiscrepancyOverridesExistingZone(): void
+    {
+        // Ticket già salvato con zona A
+        $user   = $this->createUser();
+        $ticket = Ticket::factory()->create([
+            'company_id' => $this->company->id,
+            'user_id'    => $user->id,
+            'zone_id'    => $this->zoneA->id,
+        ]);
+
+        // Update porta location in A ma testo verso B
+        $this->mockNominatimWithPoint(self::POINT_IN_B['lat'], self::POINT_IN_B['lon']);
+
+        Sanctum::actingAs($user);
+
+        $this->patch(self::API_PREFIX_TICKET . "{$ticket->id}", [
+            'address'     => 'Via Giovanni XXIII',
+            'house_number' => '9',
+            'city'        => 'Fosdinovo',
+            'location'    => [self::POINT_IN_A['lon'], self::POINT_IN_A['lat']],
+        ]);
+
+        $this->assertDatabaseHas('tickets', [
+            'id'      => $ticket->id,
+            'zone_id' => $this->zoneB->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Aggiunto `_correctLocationFromAddress()` in `TicketController`: forward geocoding Nominatim su `v1store`/`v1update` quando `address_id` è null; se la zona del testo ≠ zona delle coordinate, sovrascrive `geometry` e `zone_id` pre-save
- Usa `Http` facade (Guzzle) con User-Agent conforme Nominatim policy — `CurlServiceProvider` bloccava le richieste con `PostmanRuntime/7.29.2`
- Fail-open su `ConnectionException`, risposta non-2xx e risultati vuoti
- Kill switch `ADDRESS_DISCREPANCY_CHECK_ENABLED` (default `true`)
- 8 test feature in `TicketDiscrepancyCheckTest` con `Http::fake()`

## Test plan

- [ ] `docker exec php_portapporta php artisan test --filter=TicketDiscrepancyCheckTest` → 8 passed
- [ ] Test manuale: creare ticket da app con indirizzo testo di comune diverso dalle coordinate → zone_id corretto nel DB
- [ ] Test kill switch: `ADDRESS_DISCREPANCY_CHECK_ENABLED=false` in `.env` → zona non modificata

🤖 Generated with [Claude Code](https://claude.com/claude-code)